### PR TITLE
Cart modification during checkout

### DIFF
--- a/catalog/admin/includes/classes/shopping_cart.php
+++ b/catalog/admin/includes/classes/shopping_cart.php
@@ -367,8 +367,12 @@
       return $this->weight;
     }
 
-    function generate_cart_id($length = 5) {
-      return tep_create_random_value($length, 'digits');
+    function as_string() {
+      $s = array();
+      foreach ($this->contents as $products_id => $products_info) {
+        $s[] = $products_id . ':' . $products_info['qty'];
+      }
+      return implode(',', $s);
     }
 
     function get_content_type() {

--- a/catalog/admin/includes/classes/shopping_cart.php
+++ b/catalog/admin/includes/classes/shopping_cart.php
@@ -11,7 +11,7 @@
 */
 
   class shoppingCart {
-    var $contents, $total, $weight;
+    var $contents, $total, $weight, $content_type;
 
     function shoppingCart() {
       $this->reset();
@@ -20,17 +20,17 @@
     function restore_contents() {
       global $customer_id;
 
-      if (!$customer_id) return 0;
+      if (!tep_session_is_registered('customer_id')) return false;
 
 // insert current cart contents in database
-      if ($this->contents) {
+      if (is_array($this->contents)) {
         reset($this->contents);
         while (list($products_id, ) = each($this->contents)) {
           $qty = $this->contents[$products_id]['qty'];
           $product_query = tep_db_query("select products_id from " . TABLE_CUSTOMERS_BASKET . " where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id) . "'");
           if (!tep_db_num_rows($product_query)) {
             tep_db_query("insert into " . TABLE_CUSTOMERS_BASKET . " (customers_id, products_id, customers_basket_quantity, customers_basket_date_added) values ('" . (int)$customer_id . "', '" . tep_db_input($products_id) . "', '" . tep_db_input($qty) . "', '" . date('Ymd') . "')");
-            if ($this->contents[$products_id]['attributes']) {
+            if (isset($this->contents[$products_id]['attributes'])) {
               reset($this->contents[$products_id]['attributes']);
               while (list($option, $value) = each($this->contents[$products_id]['attributes'])) {
                 tep_db_query("insert into " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " (customers_id, products_id, products_options_id, products_options_value_id) values ('" . (int)$customer_id . "', '" . tep_db_input($products_id) . "', '" . (int)$option . "', '" . (int)$value . "')");
@@ -42,8 +42,8 @@
         }
       }
 
-// reset per-session cart contents, but not the database contents
-      $this->reset(FALSE);
+// reset per-session cart contents, but not the database contents (this also resets the checkout)
+      $this->reset(false);
 
       $products_query = tep_db_query("select products_id, customers_basket_quantity from " . TABLE_CUSTOMERS_BASKET . " where customers_id = '" . (int)$customer_id . "'");
       while ($products = tep_db_fetch_array($products_query)) {
@@ -58,62 +58,128 @@
       $this->cleanup();
     }
 
-    function reset($reset_database = FALSE) {
+    function reset($reset_database = false) {
       global $customer_id;
 
+      $this->reset_checkout();
       $this->contents = array();
       $this->total = 0;
+      $this->weight = 0;
+      $this->content_type = false;
 
-      if ($customer_id && $reset_database) {
+      if (tep_session_is_registered('customer_id') && ($reset_database == true)) {
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET . " where customers_id = '" . (int)$customer_id . "'");
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " where customers_id = '" . (int)$customer_id . "'");
       }
     }
 
-    function add_cart($products_id, $qty = '', $attributes = '') {
+// resets checkout data, should be used after any cart modification to prevent wrong shipping / payment costs
+    function reset_checkout() {
+      global $shipping, $payment;
+      $shipping = null;
+      $payment = null;
+      if (tep_session_is_registered('shipping')) tep_session_unregister('shipping');
+      if (tep_session_is_registered('payment')) tep_session_unregister('payment');
+    }
+
+    function add_cart($products_id, $qty = '1', $attributes = '', $notify = true) {
       global $new_products_id_in_cart, $customer_id;
 
-      $products_id = tep_get_uprid($products_id, $attributes);
+      $products_id_string = tep_get_uprid($products_id, $attributes);
+      $products_id = tep_get_prid($products_id_string);
 
-      if ($this->in_cart($products_id)) {
-        $this->update_quantity($products_id, $qty, $attributes);
-      } else {
-        if ($qty == '') $qty = '1'; // if no quantity is supplied, then add '1' to the customers basket
+      if (defined('MAX_QTY_IN_CART') && (MAX_QTY_IN_CART > 0) && ((int)$qty > MAX_QTY_IN_CART)) {
+        $qty = MAX_QTY_IN_CART;
+      }
 
-        $this->contents[] = array($products_id);
-        $this->contents[$products_id] = array('qty' => $qty);
-// insert into database
-        if ($customer_id) tep_db_query("insert into " . TABLE_CUSTOMERS_BASKET . " (customers_id, products_id, customers_basket_quantity, customers_basket_date_added) values ('" . (int)$customer_id . "', '" . tep_db_input($products_id) . "', '" . tep_db_input($qty) . "', '" . date('Ymd') . "')");
+      $attributes_pass_check = true;
 
-        if (is_array($attributes)) {
-          reset($attributes);
-          while (list($option, $value) = each($attributes)) {
-            $this->contents[$products_id]['attributes'][$option] = $value;
-// insert into database
-            if ($customer_id) tep_db_query("insert into " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " (customers_id, products_id, products_options_id, products_options_value_id) values ('" . (int)$customer_id . "', '" . tep_db_input($products_id) . "', '" . (int)$option . "', '" . (int)$value . "')");
+      if (is_array($attributes) && !empty($attributes)) {
+        reset($attributes);
+        while (list($option, $value) = each($attributes)) {
+          if (!is_numeric($option) || !is_numeric($value)) {
+            $attributes_pass_check = false;
+            break;
+          } else {
+            $check_query = tep_db_query("select products_attributes_id from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id = '" . (int)$products_id . "' and options_id = '" . (int)$option . "' and options_values_id = '" . (int)$value . "' limit 1");
+            if (tep_db_num_rows($check_query) < 1) {
+              $attributes_pass_check = false;
+              break;
+            }
           }
         }
-        $new_products_id_in_cart = $products_id;
-        tep_session_register('new_products_id_in_cart');
+      } elseif (tep_has_product_attributes($products_id)) {
+        $attributes_pass_check = false;
       }
-      $this->cleanup();
+
+      if (is_numeric($products_id) && is_numeric($qty) && ($attributes_pass_check == true)) {
+        $check_product_query = tep_db_query("select products_status from " . TABLE_PRODUCTS . " where products_id = '" . (int)$products_id . "'");
+        $check_product = tep_db_fetch_array($check_product_query);
+
+        if (($check_product !== false) && ($check_product['products_status'] == '1')) {
+          if ($notify == true) {
+            $new_products_id_in_cart = $products_id;
+            tep_session_register('new_products_id_in_cart');
+          }
+
+          if ($this->in_cart($products_id_string)) {
+            $this->update_quantity($products_id_string, $qty, $attributes);
+          } else {
+            $this->reset_checkout();
+            $this->contents[$products_id_string] = array('qty' => (int)$qty);
+// insert into database
+            if (tep_session_is_registered('customer_id')) tep_db_query("insert into " . TABLE_CUSTOMERS_BASKET . " (customers_id, products_id, customers_basket_quantity, customers_basket_date_added) values ('" . (int)$customer_id . "', '" . tep_db_input($products_id_string) . "', '" . (int)$qty . "', '" . date('Ymd') . "')");
+
+            if (is_array($attributes)) {
+              reset($attributes);
+              while (list($option, $value) = each($attributes)) {
+                $this->contents[$products_id_string]['attributes'][$option] = $value;
+// insert into database
+                if (tep_session_is_registered('customer_id')) tep_db_query("insert into " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " (customers_id, products_id, products_options_id, products_options_value_id) values ('" . (int)$customer_id . "', '" . tep_db_input($products_id_string) . "', '" . (int)$option . "', '" . (int)$value . "')");
+              }
+            }
+          }
+
+          $this->cleanup();
+        }
+      }
     }
 
     function update_quantity($products_id, $quantity = '', $attributes = '') {
       global $customer_id;
 
-      if ($quantity == '') return true; // nothing needs to be updated if theres no quantity, so we return true..
+      $products_id_string = tep_get_uprid($products_id, $attributes);
+      $products_id = tep_get_prid($products_id_string);
 
-      $this->contents[$products_id] = array('qty' => $quantity);
-// update database
-      if ($customer_id) tep_db_query("update " . TABLE_CUSTOMERS_BASKET . " set customers_basket_quantity = '" . tep_db_input($quantity) . "' where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id) . "'");
+      if (defined('MAX_QTY_IN_CART') && (MAX_QTY_IN_CART > 0) && ((int)$quantity > MAX_QTY_IN_CART)) {
+        $quantity = MAX_QTY_IN_CART;
+      }
+
+      $attributes_pass_check = true;
 
       if (is_array($attributes)) {
         reset($attributes);
         while (list($option, $value) = each($attributes)) {
-          $this->contents[$products_id]['attributes'][$option] = $value;
+          if (!is_numeric($option) || !is_numeric($value)) {
+            $attributes_pass_check = false;
+            break;
+          }
+        }
+      }
+
+      if (is_numeric($products_id) && isset($this->contents[$products_id_string]) && is_numeric($quantity) && ($attributes_pass_check == true)) {
+        $this->reset_checkout();
+        $this->contents[$products_id_string] = array('qty' => (int)$quantity);
 // update database
-          if ($customer_id) tep_db_query("update " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " set products_options_value_id = '" . (int)$value . "' where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id) . "' and products_options_id = '" . (int)$option . "'");
+        if (tep_session_is_registered('customer_id')) tep_db_query("update " . TABLE_CUSTOMERS_BASKET . " set customers_basket_quantity = '" . (int)$quantity . "' where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id_string) . "'");
+
+        if (is_array($attributes)) {
+          reset($attributes);
+          while (list($option, $value) = each($attributes)) {
+            $this->contents[$products_id_string]['attributes'][$option] = $value;
+// update database
+            if (tep_session_is_registered('customer_id')) tep_db_query("update " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " set products_options_value_id = '" . (int)$value . "' where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id_string) . "' and products_options_id = '" . (int)$option . "'");
+          }
         }
       }
     }
@@ -126,7 +192,7 @@
         if ($this->contents[$key]['qty'] < 1) {
           unset($this->contents[$key]);
 // remove from database
-          if ($customer_id) {
+          if (tep_session_is_registered('customer_id')) {
             tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET . " where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($key) . "'");
             tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($key) . "'");
           }
@@ -135,18 +201,19 @@
     }
 
     function count_contents() {  // get total number of items in cart 
-        $total_items = 0;
-        if (is_array($this->contents)) {
-            reset($this->contents);
-            while (list($products_id, ) = each($this->contents)) {
-                $total_items += $this->get_quantity($products_id);
-            }
+      $total_items = 0;
+      if (is_array($this->contents)) {
+        reset($this->contents);
+        while (list($products_id, ) = each($this->contents)) {
+          $total_items += $this->get_quantity($products_id);
         }
-        return $total_items;
+      }
+
+      return $total_items;
     }
 
     function get_quantity($products_id) {
-      if ($this->contents[$products_id]) {
+      if (isset($this->contents[$products_id])) {
         return $this->contents[$products_id]['qty'];
       } else {
         return 0;
@@ -154,7 +221,7 @@
     }
 
     function in_cart($products_id) {
-      if ($this->contents[$products_id]) {
+      if (isset($this->contents[$products_id])) {
         return true;
       } else {
         return false;
@@ -164,9 +231,10 @@
     function remove($products_id) {
       global $customer_id;
 
+      $this->reset_checkout();
       unset($this->contents[$products_id]);
 // remove from database
-      if ($customer_id) {
+      if (tep_session_is_registered('customer_id')) {
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET . " where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id) . "'");
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id) . "'");
       }
@@ -178,17 +246,19 @@
 
     function get_product_id_list() {
       $product_id_list = '';
-      if (is_array($this->contents))
-      {
+      if (is_array($this->contents)) {
         reset($this->contents);
         while (list($products_id, ) = each($this->contents)) {
           $product_id_list .= ', ' . $products_id;
         }
       }
+
       return substr($product_id_list, 2);
     }
 
     function calculate() {
+      global $currencies;
+
       $this->total = 0;
       $this->weight = 0;
       if (!is_array($this->contents)) return 0;
@@ -198,7 +268,7 @@
         $qty = $this->contents[$products_id]['qty'];
 
 // products price
-        $product_query = tep_db_query("select products_id, products_price, products_tax_class_id, products_weight from " . TABLE_PRODUCTS . " where products_id='" . (int)tep_get_prid($products_id) . "'");
+        $product_query = tep_db_query("select products_id, products_price, products_tax_class_id, products_weight from " . TABLE_PRODUCTS . " where products_id = '" . (int)$products_id . "'");
         if ($product = tep_db_fetch_array($product_query)) {
           $prid = $product['products_id'];
           $products_tax = tep_get_tax_rate($product['products_tax_class_id']);
@@ -211,7 +281,7 @@
             $products_price = $specials['specials_new_products_price'];
           }
 
-          $this->total += tep_add_tax($products_price, $products_tax) * $qty;
+          $this->total += $currencies->calculate_price($products_price, $products_tax, $qty);
           $this->weight += ($qty * $products_weight);
         }
 
@@ -222,9 +292,9 @@
             $attribute_price_query = tep_db_query("select options_values_price, price_prefix from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id = '" . (int)$prid . "' and options_id = '" . (int)$option . "' and options_values_id = '" . (int)$value . "'");
             $attribute_price = tep_db_fetch_array($attribute_price_query);
             if ($attribute_price['price_prefix'] == '+') {
-              $this->total += $qty * tep_add_tax($attribute_price['options_values_price'], $products_tax);
+              $this->total += $currencies->calculate_price($attribute_price['options_values_price'], $products_tax, $qty);
             } else {
-              $this->total -= $qty * tep_add_tax($attribute_price['options_values_price'], $products_tax);
+              $this->total -= $currencies->calculate_price($attribute_price['options_values_price'], $products_tax, $qty);
             }
           }
         }
@@ -253,11 +323,12 @@
     function get_products() {
       global $languages_id;
 
-      if (!is_array($this->contents)) return 0;
+      if (!is_array($this->contents)) return false;
+
       $products_array = array();
       reset($this->contents);
       while (list($products_id, ) = each($this->contents)) {
-        $products_query = tep_db_query("select p.products_id, pd.products_name, p.products_model, p.products_price, p.products_weight, p.products_tax_class_id from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd where p.products_id='" . (int)tep_get_prid($products_id) . "' and pd.products_id = p.products_id and pd.language_id = '" . (int)$languages_id . "'");
+        $products_query = tep_db_query("select p.products_id, pd.products_name, p.products_model, p.products_image, p.products_price, p.products_weight, p.products_tax_class_id from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd where p.products_id = '" . (int)$products_id . "' and pd.products_id = p.products_id and pd.language_id = '" . (int)$languages_id . "'");
         if ($products = tep_db_fetch_array($products_query)) {
           $prid = $products['products_id'];
           $products_price = $products['products_price'];
@@ -271,6 +342,7 @@
           $products_array[] = array('id' => $products_id,
                                     'name' => $products['products_name'],
                                     'model' => $products['products_model'],
+                                    'image' => $products['products_image'],
                                     'price' => $products_price,
                                     'quantity' => $this->contents[$products_id]['qty'],
                                     'weight' => $products['products_weight'],
@@ -279,6 +351,7 @@
                                     'attributes' => (isset($this->contents[$products_id]['attributes']) ? $this->contents[$products_id]['attributes'] : ''));
         }
       }
+
       return $products_array;
     }
 
@@ -292,6 +365,66 @@
       $this->calculate();
 
       return $this->weight;
+    }
+
+    function generate_cart_id($length = 5) {
+      return tep_create_random_value($length, 'digits');
+    }
+
+    function get_content_type() {
+      $this->content_type = false;
+
+      if ( (DOWNLOAD_ENABLED == 'true') && ($this->count_contents() > 0) ) {
+        reset($this->contents);
+        while (list($products_id, ) = each($this->contents)) {
+          if (isset($this->contents[$products_id]['attributes'])) {
+            reset($this->contents[$products_id]['attributes']);
+            while (list(, $value) = each($this->contents[$products_id]['attributes'])) {
+              $virtual_check_query = tep_db_query("select count(*) as total from " . TABLE_PRODUCTS_ATTRIBUTES . " pa, " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad where pa.products_id = '" . (int)$products_id . "' and pa.options_values_id = '" . (int)$value . "' and pa.products_attributes_id = pad.products_attributes_id");
+              $virtual_check = tep_db_fetch_array($virtual_check_query);
+
+              if ($virtual_check['total'] > 0) {
+                switch ($this->content_type) {
+                  case 'physical':
+                    $this->content_type = 'mixed';
+
+                    return $this->content_type;
+                    break;
+                  default:
+                    $this->content_type = 'virtual';
+                    break;
+                }
+              } else {
+                switch ($this->content_type) {
+                  case 'virtual':
+                    $this->content_type = 'mixed';
+
+                    return $this->content_type;
+                    break;
+                  default:
+                    $this->content_type = 'physical';
+                    break;
+                }
+              }
+            }
+          } else {
+            switch ($this->content_type) {
+              case 'virtual':
+                $this->content_type = 'mixed';
+
+                return $this->content_type;
+                break;
+              default:
+                $this->content_type = 'physical';
+                break;
+            }
+          }
+        }
+      } else {
+        $this->content_type = 'physical';
+      }
+
+      return $this->content_type;
     }
 
     function unserialize($broken) {

--- a/catalog/checkout_confirmation.php
+++ b/catalog/checkout_confirmation.php
@@ -23,13 +23,6 @@
     tep_redirect(tep_href_link(FILENAME_SHOPPING_CART));
   }
 
-// avoid hack attempts during the checkout procedure by checking the internal cartID
-  if (isset($cart->cartID) && tep_session_is_registered('cartID')) {
-    if ($cart->cartID != $cartID) {
-      tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-    }
-  }
-
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!tep_session_is_registered('shipping')) {
     tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));

--- a/catalog/checkout_payment.php
+++ b/catalog/checkout_payment.php
@@ -28,13 +28,6 @@
     tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
   }
 
-// avoid hack attempts during the checkout procedure by checking the internal cartID
-  if (isset($cart->cartID) && tep_session_is_registered('cartID')) {
-    if ($cart->cartID != $cartID) {
-      tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-    }
-  }
-
 // Stock Check
   if ( (STOCK_CHECK == 'true') && (STOCK_ALLOW_CHECKOUT != 'true') ) {
     $products = $cart->get_products();

--- a/catalog/checkout_process.php
+++ b/catalog/checkout_process.php
@@ -32,13 +32,6 @@
     tep_redirect(tep_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
  }
 
-// avoid hack attempts during the checkout procedure by checking the internal cartID
-  if (isset($cart->cartID) && tep_session_is_registered('cartID')) {
-    if ($cart->cartID != $cartID) {
-      tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-    }
-  }
-
   include(DIR_WS_LANGUAGES . $language . '/' . FILENAME_CHECKOUT_PROCESS);
 
 // load selected payment module

--- a/catalog/checkout_shipping.php
+++ b/catalog/checkout_shipping.php
@@ -44,11 +44,6 @@
   require(DIR_WS_CLASSES . 'order.php');
   $order = new order;
 
-// register a random ID in the session to check throughout the checkout procedure
-// against alterations in the shopping cart contents
-  if (!tep_session_is_registered('cartID')) tep_session_register('cartID');
-  $cartID = $cart->cartID;
-
 // if the order contains only virtual products, forward the customer to the billing page as
 // a shipping address is not needed
   if ($order->content_type == 'virtual') {

--- a/catalog/ext/modules/payment/moneybookers/checkout.php
+++ b/catalog/ext/modules/payment/moneybookers/checkout.php
@@ -24,13 +24,6 @@
     tep_redirect(tep_href_link(FILENAME_SHOPPING_CART));
   }
 
-// avoid hack attempts during the checkout procedure by checking the internal cartID
-  if (isset($cart->cartID) && tep_session_is_registered('cartID')) {
-    if ($cart->cartID != $cartID) {
-      tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-    }
-  }
-
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!tep_session_is_registered('shipping')) {
     tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));

--- a/catalog/ext/modules/payment/paypal/express.php
+++ b/catalog/ext/modules/payment/paypal/express.php
@@ -39,11 +39,6 @@
     $billto = $customer_default_address_id;
   }
 
-// register a random ID in the session to check throughout the checkout procedure
-// against alterations in the shopping cart contents
-  if (!tep_session_is_registered('cartID')) tep_session_register('cartID');
-  $cartID = $cart->cartID;
-
   switch ($HTTP_GET_VARS['osC_Action']) {
     case 'cancel':
       tep_session_unregister('ppe_token');

--- a/catalog/ext/modules/payment/paypal/express_payflow.php
+++ b/catalog/ext/modules/payment/paypal/express_payflow.php
@@ -57,11 +57,6 @@
     $billto = $customer_default_address_id;
   }
 
-// register a random ID in the session to check throughout the checkout procedure
-// against alterations in the shopping cart contents
-  if (!tep_session_is_registered('cartID')) tep_session_register('cartID');
-  $cartID = $cart->cartID;
-
   $params = array('USER' => (tep_not_null(MODULE_PAYMENT_PAYPAL_PRO_PAYFLOW_EC_USERNAME) ? MODULE_PAYMENT_PAYPAL_PRO_PAYFLOW_EC_USERNAME : MODULE_PAYMENT_PAYPAL_PRO_PAYFLOW_EC_VENDOR),
                   'VENDOR' => MODULE_PAYMENT_PAYPAL_PRO_PAYFLOW_EC_VENDOR,
                   'PARTNER' => MODULE_PAYMENT_PAYPAL_PRO_PAYFLOW_EC_PARTNER,
@@ -82,7 +77,7 @@
 
       $post_string = substr($post_string, 0, -1);
 
-      $response = $paypal_pro_payflow_ec->sendTransactionToGateway($api_url, $post_string, array('X-VPS-REQUEST-ID: ' . md5($cartID . tep_session_id() . rand())));
+      $response = $paypal_pro_payflow_ec->sendTransactionToGateway($api_url, $post_string, array('X-VPS-REQUEST-ID: ' . md5(tep_session_id() . rand())));
       $response_array = array();
       parse_str($response, $response_array);
 
@@ -283,7 +278,7 @@
 
       $post_string = substr($post_string, 0, -1);
 
-      $response = $paypal_pro_payflow_ec->sendTransactionToGateway($api_url, $post_string, array('X-VPS-REQUEST-ID: ' . md5($cartID . tep_session_id() . rand())));
+      $response = $paypal_pro_payflow_ec->sendTransactionToGateway($api_url, $post_string, array('X-VPS-REQUEST-ID: ' . md5(tep_session_id() . rand())));
       $response_array = array();
       parse_str($response, $response_array);
 

--- a/catalog/ext/modules/payment/sage_pay/checkout.php
+++ b/catalog/ext/modules/payment/sage_pay/checkout.php
@@ -24,13 +24,6 @@
     tep_redirect(tep_href_link(FILENAME_SHOPPING_CART));
   }
 
-// avoid hack attempts during the checkout procedure by checking the internal cartID
-  if (isset($cart->cartID) && tep_session_is_registered('cartID')) {
-    if ($cart->cartID != $cartID) {
-      tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
-    }
-  }
-
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!tep_session_is_registered('shipping')) {
     tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));

--- a/catalog/includes/classes/shopping_cart.php
+++ b/catalog/includes/classes/shopping_cart.php
@@ -367,8 +367,12 @@
       return $this->weight;
     }
 
-    function generate_cart_id($length = 5) {
-      return tep_create_random_value($length, 'digits');
+    function as_string() {
+      $s = array();
+      foreach ($this->contents as $products_id => $products_info) {
+        $s[] = $products_id . ':' . $products_info['qty'];
+      }
+      return implode(',', $s);
     }
 
     function get_content_type() {

--- a/catalog/includes/classes/shopping_cart.php
+++ b/catalog/includes/classes/shopping_cart.php
@@ -11,7 +11,7 @@
 */
 
   class shoppingCart {
-    var $contents, $total, $weight, $cartID, $content_type;
+    var $contents, $total, $weight, $content_type;
 
     function shoppingCart() {
       $this->reset();
@@ -42,7 +42,7 @@
         }
       }
 
-// reset per-session cart contents, but not the database contents
+// reset per-session cart contents, but not the database contents (this also resets the checkout)
       $this->reset(false);
 
       $products_query = tep_db_query("select products_id, customers_basket_quantity from " . TABLE_CUSTOMERS_BASKET . " where customers_id = '" . (int)$customer_id . "'");
@@ -56,14 +56,12 @@
       }
 
       $this->cleanup();
-
-// assign a temporary unique ID to the order contents to prevent hack attempts during the checkout procedure
-      $this->cartID = $this->generate_cart_id();
     }
 
     function reset($reset_database = false) {
       global $customer_id;
 
+      $this->reset_checkout();
       $this->contents = array();
       $this->total = 0;
       $this->weight = 0;
@@ -73,9 +71,15 @@
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET . " where customers_id = '" . (int)$customer_id . "'");
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " where customers_id = '" . (int)$customer_id . "'");
       }
+    }
 
-      unset($this->cartID);
-      if (tep_session_is_registered('cartID')) tep_session_unregister('cartID');
+// resets checkout data, should be used after any cart modification to prevent wrong shipping / payment costs
+    function reset_checkout() {
+      global $shipping, $payment;
+      $shipping = null;
+      $payment = null;
+      if (tep_session_is_registered('shipping')) tep_session_unregister('shipping');
+      if (tep_session_is_registered('payment')) tep_session_unregister('payment');
     }
 
     function add_cart($products_id, $qty = '1', $attributes = '', $notify = true) {
@@ -121,6 +125,7 @@
           if ($this->in_cart($products_id_string)) {
             $this->update_quantity($products_id_string, $qty, $attributes);
           } else {
+            $this->reset_checkout();
             $this->contents[$products_id_string] = array('qty' => (int)$qty);
 // insert into database
             if (tep_session_is_registered('customer_id')) tep_db_query("insert into " . TABLE_CUSTOMERS_BASKET . " (customers_id, products_id, customers_basket_quantity, customers_basket_date_added) values ('" . (int)$customer_id . "', '" . tep_db_input($products_id_string) . "', '" . (int)$qty . "', '" . date('Ymd') . "')");
@@ -136,9 +141,6 @@
           }
 
           $this->cleanup();
-
-// assign a temporary unique ID to the order contents to prevent hack attempts during the checkout procedure
-          $this->cartID = $this->generate_cart_id();
         }
       }
     }
@@ -166,6 +168,7 @@
       }
 
       if (is_numeric($products_id) && isset($this->contents[$products_id_string]) && is_numeric($quantity) && ($attributes_pass_check == true)) {
+        $this->reset_checkout();
         $this->contents[$products_id_string] = array('qty' => (int)$quantity);
 // update database
         if (tep_session_is_registered('customer_id')) tep_db_query("update " . TABLE_CUSTOMERS_BASKET . " set customers_basket_quantity = '" . (int)$quantity . "' where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id_string) . "'");
@@ -228,15 +231,13 @@
     function remove($products_id) {
       global $customer_id;
 
+      $this->reset_checkout();
       unset($this->contents[$products_id]);
 // remove from database
       if (tep_session_is_registered('customer_id')) {
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET . " where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id) . "'");
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id) . "'");
       }
-
-// assign a temporary unique ID to the order contents to prevent hack attempts during the checkout procedure
-      $this->cartID = $this->generate_cart_id();
     }
 
     function remove_all() {

--- a/catalog/includes/modules/payment/chronopay.php
+++ b/catalog/includes/modules/payment/chronopay.php
@@ -87,183 +87,173 @@
     }
 
     function pre_confirmation_check() {
-      global $cartID, $cart;
-
-      if (empty($cart->cartID)) {
-        $cartID = $cart->cartID = $cart->generate_cart_id();
-      }
-
-      if (!tep_session_is_registered('cartID')) {
-        tep_session_register('cartID');
-      }
+      return false;
     }
 
     function confirmation() {
-      global $cartID, $cart_ChronoPay_ID, $customer_id, $languages_id, $order, $order_total_modules;
+      global $cart, $cart_ChronoPay_ID, $customer_id, $languages_id, $order, $order_total_modules;
 
-      if (tep_session_is_registered('cartID')) {
-        $insert_order = false;
+      $insert_order = false;
 
-        if (tep_session_is_registered('cart_ChronoPay_ID')) {
-          $order_id = substr($cart_ChronoPay_ID, strpos($cart_ChronoPay_ID, '-')+1);
+      if (tep_session_is_registered('cart_ChronoPay_ID')) {
+        list($cart_string, $order_id) = explode($cart_ChronoPay_ID, '-', 2);
 
-          $curr_check = tep_db_query("select currency from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
-          $curr = tep_db_fetch_array($curr_check);
+        $curr_check = tep_db_query("select currency from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
+        $curr = tep_db_fetch_array($curr_check);
 
-          if ( ($curr['currency'] != $order->info['currency']) || ($cartID != substr($cart_ChronoPay_ID, 0, strlen($cartID))) ) {
-            $check_query = tep_db_query('select orders_id from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '" limit 1');
+        if ( ($curr['currency'] != $order->info['currency']) || ($cart_string != $cart->as_string()) ) {
+          $check_query = tep_db_query('select orders_id from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '" limit 1');
 
-            if (tep_db_num_rows($check_query) < 1) {
-              tep_db_query('delete from ' . TABLE_ORDERS . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_TOTAL . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS_DOWNLOAD . ' where orders_id = "' . (int)$order_id . '"');
-            }
-
-            $insert_order = true;
+          if (tep_db_num_rows($check_query) < 1) {
+            tep_db_query('delete from ' . TABLE_ORDERS . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_TOTAL . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS_DOWNLOAD . ' where orders_id = "' . (int)$order_id . '"');
           }
-        } else {
+
           $insert_order = true;
         }
+      } else {
+        $insert_order = true;
+      }
 
-        if ($insert_order == true) {
-          $order_totals = array();
-          if (is_array($order_total_modules->modules)) {
-            reset($order_total_modules->modules);
-            while (list(, $value) = each($order_total_modules->modules)) {
-              $class = substr($value, 0, strrpos($value, '.'));
-              if ($GLOBALS[$class]->enabled) {
-                for ($i=0, $n=sizeof($GLOBALS[$class]->output); $i<$n; $i++) {
-                  if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text'])) {
-                    $order_totals[] = array('code' => $GLOBALS[$class]->code,
-                                            'title' => $GLOBALS[$class]->output[$i]['title'],
-                                            'text' => $GLOBALS[$class]->output[$i]['text'],
-                                            'value' => $GLOBALS[$class]->output[$i]['value'],
-                                            'sort_order' => $GLOBALS[$class]->sort_order);
-                  }
+      if ($insert_order == true) {
+        $order_totals = array();
+        if (is_array($order_total_modules->modules)) {
+          reset($order_total_modules->modules);
+          while (list(, $value) = each($order_total_modules->modules)) {
+            $class = substr($value, 0, strrpos($value, '.'));
+            if ($GLOBALS[$class]->enabled) {
+              for ($i=0, $n=sizeof($GLOBALS[$class]->output); $i<$n; $i++) {
+                if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text'])) {
+                  $order_totals[] = array('code' => $GLOBALS[$class]->code,
+                                          'title' => $GLOBALS[$class]->output[$i]['title'],
+                                          'text' => $GLOBALS[$class]->output[$i]['text'],
+                                          'value' => $GLOBALS[$class]->output[$i]['value'],
+                                          'sort_order' => $GLOBALS[$class]->sort_order);
                 }
               }
             }
           }
+        }
 
-          $sql_data_array = array('customers_id' => $customer_id,
-                                  'customers_name' => $order->customer['firstname'] . ' ' . $order->customer['lastname'],
-                                  'customers_company' => $order->customer['company'],
-                                  'customers_street_address' => $order->customer['street_address'],
-                                  'customers_suburb' => $order->customer['suburb'],
-                                  'customers_city' => $order->customer['city'],
-                                  'customers_postcode' => $order->customer['postcode'],
-                                  'customers_state' => $order->customer['state'],
-                                  'customers_country' => $order->customer['country']['title'],
-                                  'customers_telephone' => $order->customer['telephone'],
-                                  'customers_email_address' => $order->customer['email_address'],
-                                  'customers_address_format_id' => $order->customer['format_id'],
-                                  'delivery_name' => $order->delivery['firstname'] . ' ' . $order->delivery['lastname'],
-                                  'delivery_company' => $order->delivery['company'],
-                                  'delivery_street_address' => $order->delivery['street_address'],
-                                  'delivery_suburb' => $order->delivery['suburb'],
-                                  'delivery_city' => $order->delivery['city'],
-                                  'delivery_postcode' => $order->delivery['postcode'],
-                                  'delivery_state' => $order->delivery['state'],
-                                  'delivery_country' => $order->delivery['country']['title'],
-                                  'delivery_address_format_id' => $order->delivery['format_id'],
-                                  'billing_name' => $order->billing['firstname'] . ' ' . $order->billing['lastname'],
-                                  'billing_company' => $order->billing['company'],
-                                  'billing_street_address' => $order->billing['street_address'],
-                                  'billing_suburb' => $order->billing['suburb'],
-                                  'billing_city' => $order->billing['city'],
-                                  'billing_postcode' => $order->billing['postcode'],
-                                  'billing_state' => $order->billing['state'],
-                                  'billing_country' => $order->billing['country']['title'],
-                                  'billing_address_format_id' => $order->billing['format_id'],
-                                  'payment_method' => $order->info['payment_method'],
-                                  'cc_type' => $order->info['cc_type'],
-                                  'cc_owner' => $order->info['cc_owner'],
-                                  'cc_number' => $order->info['cc_number'],
-                                  'cc_expires' => $order->info['cc_expires'],
-                                  'date_purchased' => 'now()',
-                                  'orders_status' => $order->info['order_status'],
-                                  'currency' => $order->info['currency'],
-                                  'currency_value' => $order->info['currency_value']);
+        $sql_data_array = array('customers_id' => $customer_id,
+                                'customers_name' => $order->customer['firstname'] . ' ' . $order->customer['lastname'],
+                                'customers_company' => $order->customer['company'],
+                                'customers_street_address' => $order->customer['street_address'],
+                                'customers_suburb' => $order->customer['suburb'],
+                                'customers_city' => $order->customer['city'],
+                                'customers_postcode' => $order->customer['postcode'],
+                                'customers_state' => $order->customer['state'],
+                                'customers_country' => $order->customer['country']['title'],
+                                'customers_telephone' => $order->customer['telephone'],
+                                'customers_email_address' => $order->customer['email_address'],
+                                'customers_address_format_id' => $order->customer['format_id'],
+                                'delivery_name' => $order->delivery['firstname'] . ' ' . $order->delivery['lastname'],
+                                'delivery_company' => $order->delivery['company'],
+                                'delivery_street_address' => $order->delivery['street_address'],
+                                'delivery_suburb' => $order->delivery['suburb'],
+                                'delivery_city' => $order->delivery['city'],
+                                'delivery_postcode' => $order->delivery['postcode'],
+                                'delivery_state' => $order->delivery['state'],
+                                'delivery_country' => $order->delivery['country']['title'],
+                                'delivery_address_format_id' => $order->delivery['format_id'],
+                                'billing_name' => $order->billing['firstname'] . ' ' . $order->billing['lastname'],
+                                'billing_company' => $order->billing['company'],
+                                'billing_street_address' => $order->billing['street_address'],
+                                'billing_suburb' => $order->billing['suburb'],
+                                'billing_city' => $order->billing['city'],
+                                'billing_postcode' => $order->billing['postcode'],
+                                'billing_state' => $order->billing['state'],
+                                'billing_country' => $order->billing['country']['title'],
+                                'billing_address_format_id' => $order->billing['format_id'],
+                                'payment_method' => $order->info['payment_method'],
+                                'cc_type' => $order->info['cc_type'],
+                                'cc_owner' => $order->info['cc_owner'],
+                                'cc_number' => $order->info['cc_number'],
+                                'cc_expires' => $order->info['cc_expires'],
+                                'date_purchased' => 'now()',
+                                'orders_status' => $order->info['order_status'],
+                                'currency' => $order->info['currency'],
+                                'currency_value' => $order->info['currency_value']);
 
-          tep_db_perform(TABLE_ORDERS, $sql_data_array);
+        tep_db_perform(TABLE_ORDERS, $sql_data_array);
 
-          $insert_id = tep_db_insert_id();
+        $insert_id = tep_db_insert_id();
 
-          for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-            $sql_data_array = array('orders_id' => $insert_id,
-                                    'title' => $order_totals[$i]['title'],
-                                    'text' => $order_totals[$i]['text'],
-                                    'value' => $order_totals[$i]['value'],
-                                    'class' => $order_totals[$i]['code'],
-                                    'sort_order' => $order_totals[$i]['sort_order']);
+        for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
+          $sql_data_array = array('orders_id' => $insert_id,
+                                  'title' => $order_totals[$i]['title'],
+                                  'text' => $order_totals[$i]['text'],
+                                  'value' => $order_totals[$i]['value'],
+                                  'class' => $order_totals[$i]['code'],
+                                  'sort_order' => $order_totals[$i]['sort_order']);
 
-            tep_db_perform(TABLE_ORDERS_TOTAL, $sql_data_array);
-          }
+          tep_db_perform(TABLE_ORDERS_TOTAL, $sql_data_array);
+        }
 
-          for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-            $sql_data_array = array('orders_id' => $insert_id,
-                                    'products_id' => tep_get_prid($order->products[$i]['id']),
-                                    'products_model' => $order->products[$i]['model'],
-                                    'products_name' => $order->products[$i]['name'],
-                                    'products_price' => $order->products[$i]['price'],
-                                    'final_price' => $order->products[$i]['final_price'],
-                                    'products_tax' => $order->products[$i]['tax'],
-                                    'products_quantity' => $order->products[$i]['qty']);
+        for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
+          $sql_data_array = array('orders_id' => $insert_id,
+                                  'products_id' => tep_get_prid($order->products[$i]['id']),
+                                  'products_model' => $order->products[$i]['model'],
+                                  'products_name' => $order->products[$i]['name'],
+                                  'products_price' => $order->products[$i]['price'],
+                                  'final_price' => $order->products[$i]['final_price'],
+                                  'products_tax' => $order->products[$i]['tax'],
+                                  'products_quantity' => $order->products[$i]['qty']);
 
-            tep_db_perform(TABLE_ORDERS_PRODUCTS, $sql_data_array);
+          tep_db_perform(TABLE_ORDERS_PRODUCTS, $sql_data_array);
 
-            $order_products_id = tep_db_insert_id();
+          $order_products_id = tep_db_insert_id();
 
-            $attributes_exist = '0';
-            if (isset($order->products[$i]['attributes'])) {
-              $attributes_exist = '1';
-              for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-                if (DOWNLOAD_ENABLED == 'true') {
-                  $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                       from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa
-                                       left join " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
-                                       on pa.products_attributes_id=pad.products_attributes_id
-                                       where pa.products_id = '" . $order->products[$i]['id'] . "'
-                                       and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "'
-                                       and pa.options_id = popt.products_options_id
-                                       and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "'
-                                       and pa.options_values_id = poval.products_options_values_id
-                                       and popt.language_id = '" . $languages_id . "'
-                                       and poval.language_id = '" . $languages_id . "'";
-                  $attributes = tep_db_query($attributes_query);
-                } else {
-                  $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa where pa.products_id = '" . $order->products[$i]['id'] . "' and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
-                }
-                $attributes_values = tep_db_fetch_array($attributes);
+          $attributes_exist = '0';
+          if (isset($order->products[$i]['attributes'])) {
+            $attributes_exist = '1';
+            for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
+              if (DOWNLOAD_ENABLED == 'true') {
+                $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
+                                     from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa
+                                     left join " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
+                                     on pa.products_attributes_id=pad.products_attributes_id
+                                     where pa.products_id = '" . $order->products[$i]['id'] . "'
+                                     and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "'
+                                     and pa.options_id = popt.products_options_id
+                                     and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "'
+                                     and pa.options_values_id = poval.products_options_values_id
+                                     and popt.language_id = '" . $languages_id . "'
+                                     and poval.language_id = '" . $languages_id . "'";
+                $attributes = tep_db_query($attributes_query);
+              } else {
+                $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa where pa.products_id = '" . $order->products[$i]['id'] . "' and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
+              }
+              $attributes_values = tep_db_fetch_array($attributes);
 
+              $sql_data_array = array('orders_id' => $insert_id,
+                                      'orders_products_id' => $order_products_id,
+                                      'products_options' => $attributes_values['products_options_name'],
+                                      'products_options_values' => $attributes_values['products_options_values_name'],
+                                      'options_values_price' => $attributes_values['options_values_price'],
+                                      'price_prefix' => $attributes_values['price_prefix']);
+
+              tep_db_perform(TABLE_ORDERS_PRODUCTS_ATTRIBUTES, $sql_data_array);
+
+              if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
                 $sql_data_array = array('orders_id' => $insert_id,
                                         'orders_products_id' => $order_products_id,
-                                        'products_options' => $attributes_values['products_options_name'],
-                                        'products_options_values' => $attributes_values['products_options_values_name'],
-                                        'options_values_price' => $attributes_values['options_values_price'],
-                                        'price_prefix' => $attributes_values['price_prefix']);
+                                        'orders_products_filename' => $attributes_values['products_attributes_filename'],
+                                        'download_maxdays' => $attributes_values['products_attributes_maxdays'],
+                                        'download_count' => $attributes_values['products_attributes_maxcount']);
 
-                tep_db_perform(TABLE_ORDERS_PRODUCTS_ATTRIBUTES, $sql_data_array);
-
-                if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
-                  $sql_data_array = array('orders_id' => $insert_id,
-                                          'orders_products_id' => $order_products_id,
-                                          'orders_products_filename' => $attributes_values['products_attributes_filename'],
-                                          'download_maxdays' => $attributes_values['products_attributes_maxdays'],
-                                          'download_count' => $attributes_values['products_attributes_maxcount']);
-
-                  tep_db_perform(TABLE_ORDERS_PRODUCTS_DOWNLOAD, $sql_data_array);
-                }
+                tep_db_perform(TABLE_ORDERS_PRODUCTS_DOWNLOAD, $sql_data_array);
               }
             }
           }
-
-          $cart_ChronoPay_ID = $cartID . '-' . $insert_id;
-          tep_session_register('cart_ChronoPay_ID');
         }
+
+        $cart_ChronoPay_ID = $cart->as_string() . '-' . $insert_id;
+        tep_session_register('cart_ChronoPay_ID');
       }
 
       return false;

--- a/catalog/includes/modules/payment/inpay.php
+++ b/catalog/includes/modules/payment/inpay.php
@@ -104,204 +104,191 @@ class inpay
 
     function pre_confirmation_check()
     {
-        global $cartID, $cart;
-
-        if ( empty($cart->cartID))
-        {
-            $cartID = $cart->cartID = $cart->generate_cart_id();
-        }
-
-        if (!tep_session_is_registered('cartID'))
-        {
-            tep_session_register('cartID');
-        }
+      return false;
     }
 
     function confirmation()
     {
-        global $cartID, $cart_inpay_Standard_ID, $customer_id, $languages_id, $order, $order_total_modules;
+        global $cart, $cart_inpay_Standard_ID, $customer_id, $languages_id, $order, $order_total_modules;
 
-        if (tep_session_is_registered('cartID'))
+        $insert_order = false;
+
+        if (tep_session_is_registered('cart_inpay_Standard_ID'))
         {
-            $insert_order = false;
+            list($cart_string, $order_id) = explode($cart_inpay_Standard_ID, '-', 2);
 
-            if (tep_session_is_registered('cart_inpay_Standard_ID'))
+            $curr_check = tep_db_query("select currency from ".TABLE_ORDERS." where orders_id = '".(int)$order_id."'");
+            $curr = tep_db_fetch_array($curr_check);
+
+            if (($curr['currency'] != $order->info['currency']) || ($cart_string != $cart->as_string())) {
             {
-                $order_id = substr($cart_inpay_Standard_ID, strpos($cart_inpay_Standard_ID, '-')+1);
+                $check_query = tep_db_query('select orders_id from '.TABLE_ORDERS_STATUS_HISTORY.' where orders_id = "'.(int)$order_id.'" limit 1');
 
-                $curr_check = tep_db_query("select currency from ".TABLE_ORDERS." where orders_id = '".(int)$order_id."'");
-                $curr = tep_db_fetch_array($curr_check);
-
-                if (($curr['currency'] != $order->info['currency']) || ($cartID != substr($cart_inpay_Standard_ID, 0, strlen($cartID))))
+                if (tep_db_num_rows($check_query) < 1)
                 {
-                    $check_query = tep_db_query('select orders_id from '.TABLE_ORDERS_STATUS_HISTORY.' where orders_id = "'.(int)$order_id.'" limit 1');
-
-                    if (tep_db_num_rows($check_query) < 1)
-                    {
-                        tep_db_query('delete from '.TABLE_ORDERS.' where orders_id = "'.(int)$order_id.'"');
-                        tep_db_query('delete from '.TABLE_ORDERS_TOTAL.' where orders_id = "'.(int)$order_id.'"');
-                        tep_db_query('delete from '.TABLE_ORDERS_STATUS_HISTORY.' where orders_id = "'.(int)$order_id.'"');
-                        tep_db_query('delete from '.TABLE_ORDERS_PRODUCTS.' where orders_id = "'.(int)$order_id.'"');
-                        tep_db_query('delete from '.TABLE_ORDERS_PRODUCTS_ATTRIBUTES.' where orders_id = "'.(int)$order_id.'"');
-                        tep_db_query('delete from '.TABLE_ORDERS_PRODUCTS_DOWNLOAD.' where orders_id = "'.(int)$order_id.'"');
-                    }
-
-                    $insert_order = true;
+                    tep_db_query('delete from '.TABLE_ORDERS.' where orders_id = "'.(int)$order_id.'"');
+                    tep_db_query('delete from '.TABLE_ORDERS_TOTAL.' where orders_id = "'.(int)$order_id.'"');
+                    tep_db_query('delete from '.TABLE_ORDERS_STATUS_HISTORY.' where orders_id = "'.(int)$order_id.'"');
+                    tep_db_query('delete from '.TABLE_ORDERS_PRODUCTS.' where orders_id = "'.(int)$order_id.'"');
+                    tep_db_query('delete from '.TABLE_ORDERS_PRODUCTS_ATTRIBUTES.' where orders_id = "'.(int)$order_id.'"');
+                    tep_db_query('delete from '.TABLE_ORDERS_PRODUCTS_DOWNLOAD.' where orders_id = "'.(int)$order_id.'"');
                 }
-            } else
-            {
+
                 $insert_order = true;
             }
+        } else
+        {
+            $insert_order = true;
+        }
 
-            if ($insert_order == true)
+        if ($insert_order == true)
+        {
+            $order_totals = array ();
+            if (is_array($order_total_modules->modules))
             {
-                $order_totals = array ();
-                if (is_array($order_total_modules->modules))
+                reset($order_total_modules->modules);
+                while ( list (, $value) = each($order_total_modules->modules))
                 {
-                    reset($order_total_modules->modules);
-                    while ( list (, $value) = each($order_total_modules->modules))
+                    $class = substr($value, 0, strrpos($value, '.'));
+                    if ($GLOBALS[$class]->enabled)
                     {
-                        $class = substr($value, 0, strrpos($value, '.'));
-                        if ($GLOBALS[$class]->enabled)
+                        for ($i = 0, $n = sizeof($GLOBALS[$class]->output); $i < $n; $i++)
                         {
-                            for ($i = 0, $n = sizeof($GLOBALS[$class]->output); $i < $n; $i++)
+                            if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text']))
                             {
-                                if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text']))
-                                {
-                                    $order_totals[] = array ('code'=>$GLOBALS[$class]->code,
-                                    'title'=>$GLOBALS[$class]->output[$i]['title'],
-                                    'text'=>$GLOBALS[$class]->output[$i]['text'],
-                                    'value'=>$GLOBALS[$class]->output[$i]['value'],
-                                    'sort_order'=>$GLOBALS[$class]->sort_order);
-                                }
+                                $order_totals[] = array ('code'=>$GLOBALS[$class]->code,
+                                'title'=>$GLOBALS[$class]->output[$i]['title'],
+                                'text'=>$GLOBALS[$class]->output[$i]['text'],
+                                'value'=>$GLOBALS[$class]->output[$i]['value'],
+                                'sort_order'=>$GLOBALS[$class]->sort_order);
                             }
                         }
                     }
                 }
+            }
 
-                $sql_data_array = array ('customers_id'=>$customer_id,
-                'customers_name'=>$order->customer['firstname'].' '.$order->customer['lastname'],
-                'customers_company'=>$order->customer['company'],
-                'customers_street_address'=>$order->customer['street_address'],
-                'customers_suburb'=>$order->customer['suburb'],
-                'customers_city'=>$order->customer['city'],
-                'customers_postcode'=>$order->customer['postcode'],
-                'customers_state'=>$order->customer['state'],
-                'customers_country'=>$order->customer['country']['title'],
-                'customers_telephone'=>$order->customer['telephone'],
-                'customers_email_address'=>$order->customer['email_address'],
-                'customers_address_format_id'=>$order->customer['format_id'],
-                'delivery_name'=>$order->delivery['firstname'].' '.$order->delivery['lastname'],
-                'delivery_company'=>$order->delivery['company'],
-                'delivery_street_address'=>$order->delivery['street_address'],
-                'delivery_suburb'=>$order->delivery['suburb'],
-                'delivery_city'=>$order->delivery['city'],
-                'delivery_postcode'=>$order->delivery['postcode'],
-                'delivery_state'=>$order->delivery['state'],
-                'delivery_country'=>$order->delivery['country']['title'],
-                'delivery_address_format_id'=>$order->delivery['format_id'],
-                'billing_name'=>$order->billing['firstname'].' '.$order->billing['lastname'],
-                'billing_company'=>$order->billing['company'],
-                'billing_street_address'=>$order->billing['street_address'],
-                'billing_suburb'=>$order->billing['suburb'],
-                'billing_city'=>$order->billing['city'],
-                'billing_postcode'=>$order->billing['postcode'],
-                'billing_state'=>$order->billing['state'],
-                'billing_country'=>$order->billing['country']['title'],
-                'billing_address_format_id'=>$order->billing['format_id'],
-                'payment_method'=>$order->info['payment_method'],
-                'cc_type'=>$order->info['cc_type'],
-                'cc_owner'=>$order->info['cc_owner'],
-                'cc_number'=>$order->info['cc_number'],
-                'cc_expires'=>$order->info['cc_expires'],
-                'date_purchased'=>'now()',
-                'orders_status'=>$order->info['order_status'],
-                'currency'=>$order->info['currency'],
-                'currency_value'=>$order->info['currency_value']);
+            $sql_data_array = array ('customers_id'=>$customer_id,
+            'customers_name'=>$order->customer['firstname'].' '.$order->customer['lastname'],
+            'customers_company'=>$order->customer['company'],
+            'customers_street_address'=>$order->customer['street_address'],
+            'customers_suburb'=>$order->customer['suburb'],
+            'customers_city'=>$order->customer['city'],
+            'customers_postcode'=>$order->customer['postcode'],
+            'customers_state'=>$order->customer['state'],
+            'customers_country'=>$order->customer['country']['title'],
+            'customers_telephone'=>$order->customer['telephone'],
+            'customers_email_address'=>$order->customer['email_address'],
+            'customers_address_format_id'=>$order->customer['format_id'],
+            'delivery_name'=>$order->delivery['firstname'].' '.$order->delivery['lastname'],
+            'delivery_company'=>$order->delivery['company'],
+            'delivery_street_address'=>$order->delivery['street_address'],
+            'delivery_suburb'=>$order->delivery['suburb'],
+            'delivery_city'=>$order->delivery['city'],
+            'delivery_postcode'=>$order->delivery['postcode'],
+            'delivery_state'=>$order->delivery['state'],
+            'delivery_country'=>$order->delivery['country']['title'],
+            'delivery_address_format_id'=>$order->delivery['format_id'],
+            'billing_name'=>$order->billing['firstname'].' '.$order->billing['lastname'],
+            'billing_company'=>$order->billing['company'],
+            'billing_street_address'=>$order->billing['street_address'],
+            'billing_suburb'=>$order->billing['suburb'],
+            'billing_city'=>$order->billing['city'],
+            'billing_postcode'=>$order->billing['postcode'],
+            'billing_state'=>$order->billing['state'],
+            'billing_country'=>$order->billing['country']['title'],
+            'billing_address_format_id'=>$order->billing['format_id'],
+            'payment_method'=>$order->info['payment_method'],
+            'cc_type'=>$order->info['cc_type'],
+            'cc_owner'=>$order->info['cc_owner'],
+            'cc_number'=>$order->info['cc_number'],
+            'cc_expires'=>$order->info['cc_expires'],
+            'date_purchased'=>'now()',
+            'orders_status'=>$order->info['order_status'],
+            'currency'=>$order->info['currency'],
+            'currency_value'=>$order->info['currency_value']);
 
-                tep_db_perform(TABLE_ORDERS, $sql_data_array);
+            tep_db_perform(TABLE_ORDERS, $sql_data_array);
 
-                $insert_id = tep_db_insert_id();
+            $insert_id = tep_db_insert_id();
 
-                for ($i = 0, $n = sizeof($order_totals); $i < $n; $i++)
+            for ($i = 0, $n = sizeof($order_totals); $i < $n; $i++)
+            {
+                $sql_data_array = array ('orders_id'=>$insert_id,
+                'title'=>$order_totals[$i]['title'],
+                'text'=>$order_totals[$i]['text'],
+                'value'=>$order_totals[$i]['value'],
+                'class'=>$order_totals[$i]['code'],
+                'sort_order'=>$order_totals[$i]['sort_order']);
+
+                tep_db_perform(TABLE_ORDERS_TOTAL, $sql_data_array);
+            }
+
+            for ($i = 0, $n = sizeof($order->products); $i < $n; $i++)
+            {
+                $sql_data_array = array ('orders_id'=>$insert_id,
+                'products_id'=>tep_get_prid($order->products[$i]['id']),
+                'products_model'=>$order->products[$i]['model'],
+                'products_name'=>$order->products[$i]['name'],
+                'products_price'=>$order->products[$i]['price'],
+                'final_price'=>$order->products[$i]['final_price'],
+                'products_tax'=>$order->products[$i]['tax'],
+                'products_quantity'=>$order->products[$i]['qty']);
+
+                tep_db_perform(TABLE_ORDERS_PRODUCTS, $sql_data_array);
+
+                $order_products_id = tep_db_insert_id();
+
+                $attributes_exist = '0';
+                if ( isset ($order->products[$i]['attributes']))
                 {
-                    $sql_data_array = array ('orders_id'=>$insert_id,
-                    'title'=>$order_totals[$i]['title'],
-                    'text'=>$order_totals[$i]['text'],
-                    'value'=>$order_totals[$i]['value'],
-                    'class'=>$order_totals[$i]['code'],
-                    'sort_order'=>$order_totals[$i]['sort_order']);
-
-                    tep_db_perform(TABLE_ORDERS_TOTAL, $sql_data_array);
-                }
-
-                for ($i = 0, $n = sizeof($order->products); $i < $n; $i++)
-                {
-                    $sql_data_array = array ('orders_id'=>$insert_id,
-                    'products_id'=>tep_get_prid($order->products[$i]['id']),
-                    'products_model'=>$order->products[$i]['model'],
-                    'products_name'=>$order->products[$i]['name'],
-                    'products_price'=>$order->products[$i]['price'],
-                    'final_price'=>$order->products[$i]['final_price'],
-                    'products_tax'=>$order->products[$i]['tax'],
-                    'products_quantity'=>$order->products[$i]['qty']);
-
-                    tep_db_perform(TABLE_ORDERS_PRODUCTS, $sql_data_array);
-
-                    $order_products_id = tep_db_insert_id();
-
-                    $attributes_exist = '0';
-                    if ( isset ($order->products[$i]['attributes']))
+                    $attributes_exist = '1';
+                    for ($j = 0, $n2 = sizeof($order->products[$i]['attributes']); $j < $n2; $j++)
                     {
-                        $attributes_exist = '1';
-                        for ($j = 0, $n2 = sizeof($order->products[$i]['attributes']); $j < $n2; $j++)
+                        if (DOWNLOAD_ENABLED == 'true')
                         {
-                            if (DOWNLOAD_ENABLED == 'true')
-                            {
-                                $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                       from ".TABLE_PRODUCTS_OPTIONS." popt, ".TABLE_PRODUCTS_OPTIONS_VALUES." poval, ".TABLE_PRODUCTS_ATTRIBUTES." pa
-                                       left join ".TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD." pad
-                                       on pa.products_attributes_id=pad.products_attributes_id
-                                       where pa.products_id = '".$order->products[$i]['id']."'
-                                       and pa.options_id = '".$order->products[$i]['attributes'][$j]['option_id']."'
-                                       and pa.options_id = popt.products_options_id
-                                       and pa.options_values_id = '".$order->products[$i]['attributes'][$j]['value_id']."'
-                                       and pa.options_values_id = poval.products_options_values_id
-                                       and popt.language_id = '".$languages_id."'
-                                       and poval.language_id = '".$languages_id."'";
-                                $attributes = tep_db_query($attributes_query);
-                            } else
-                            {
-                                $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from ".TABLE_PRODUCTS_OPTIONS." popt, ".TABLE_PRODUCTS_OPTIONS_VALUES." poval, ".TABLE_PRODUCTS_ATTRIBUTES." pa where pa.products_id = '".$order->products[$i]['id']."' and pa.options_id = '".$order->products[$i]['attributes'][$j]['option_id']."' and pa.options_id = popt.products_options_id and pa.options_values_id = '".$order->products[$i]['attributes'][$j]['value_id']."' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '".$languages_id."' and poval.language_id = '".$languages_id."'");
-                            }
-                            $attributes_values = tep_db_fetch_array($attributes);
+                            $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
+                                   from ".TABLE_PRODUCTS_OPTIONS." popt, ".TABLE_PRODUCTS_OPTIONS_VALUES." poval, ".TABLE_PRODUCTS_ATTRIBUTES." pa
+                                   left join ".TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD." pad
+                                   on pa.products_attributes_id=pad.products_attributes_id
+                                   where pa.products_id = '".$order->products[$i]['id']."'
+                                   and pa.options_id = '".$order->products[$i]['attributes'][$j]['option_id']."'
+                                   and pa.options_id = popt.products_options_id
+                                   and pa.options_values_id = '".$order->products[$i]['attributes'][$j]['value_id']."'
+                                   and pa.options_values_id = poval.products_options_values_id
+                                   and popt.language_id = '".$languages_id."'
+                                   and poval.language_id = '".$languages_id."'";
+                            $attributes = tep_db_query($attributes_query);
+                        } else
+                        {
+                            $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from ".TABLE_PRODUCTS_OPTIONS." popt, ".TABLE_PRODUCTS_OPTIONS_VALUES." poval, ".TABLE_PRODUCTS_ATTRIBUTES." pa where pa.products_id = '".$order->products[$i]['id']."' and pa.options_id = '".$order->products[$i]['attributes'][$j]['option_id']."' and pa.options_id = popt.products_options_id and pa.options_values_id = '".$order->products[$i]['attributes'][$j]['value_id']."' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '".$languages_id."' and poval.language_id = '".$languages_id."'");
+                        }
+                        $attributes_values = tep_db_fetch_array($attributes);
 
+                        $sql_data_array = array ('orders_id'=>$insert_id,
+                        'orders_products_id'=>$order_products_id,
+                        'products_options'=>$attributes_values['products_options_name'],
+                        'products_options_values'=>$attributes_values['products_options_values_name'],
+                        'options_values_price'=>$attributes_values['options_values_price'],
+                        'price_prefix'=>$attributes_values['price_prefix']);
+
+                        tep_db_perform(TABLE_ORDERS_PRODUCTS_ATTRIBUTES, $sql_data_array);
+
+                        if ((DOWNLOAD_ENABLED == 'true') && isset ($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename']))
+                        {
                             $sql_data_array = array ('orders_id'=>$insert_id,
                             'orders_products_id'=>$order_products_id,
-                            'products_options'=>$attributes_values['products_options_name'],
-                            'products_options_values'=>$attributes_values['products_options_values_name'],
-                            'options_values_price'=>$attributes_values['options_values_price'],
-                            'price_prefix'=>$attributes_values['price_prefix']);
+                            'orders_products_filename'=>$attributes_values['products_attributes_filename'],
+                            'download_maxdays'=>$attributes_values['products_attributes_maxdays'],
+                            'download_count'=>$attributes_values['products_attributes_maxcount']);
 
-                            tep_db_perform(TABLE_ORDERS_PRODUCTS_ATTRIBUTES, $sql_data_array);
-
-                            if ((DOWNLOAD_ENABLED == 'true') && isset ($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename']))
-                            {
-                                $sql_data_array = array ('orders_id'=>$insert_id,
-                                'orders_products_id'=>$order_products_id,
-                                'orders_products_filename'=>$attributes_values['products_attributes_filename'],
-                                'download_maxdays'=>$attributes_values['products_attributes_maxdays'],
-                                'download_count'=>$attributes_values['products_attributes_maxcount']);
-
-                                tep_db_perform(TABLE_ORDERS_PRODUCTS_DOWNLOAD, $sql_data_array);
-                            }
+                            tep_db_perform(TABLE_ORDERS_PRODUCTS_DOWNLOAD, $sql_data_array);
                         }
                     }
                 }
-
-                $cart_inpay_Standard_ID = $cartID.'-'.$insert_id;
-                tep_session_register('cart_inpay_Standard_ID');
             }
+
+            $cart_inpay_Standard_ID = $cart->as_string().'-'.$insert_id;
+            tep_session_register('cart_inpay_Standard_ID');
         }
 
         return false;

--- a/catalog/includes/modules/payment/inpay.php
+++ b/catalog/includes/modules/payment/inpay.php
@@ -597,7 +597,7 @@ class inpay
             $status = tep_db_fetch_array($status_query);
             $status_id = $status['status_id']+1;
             $languages = tep_get_languages();
-			$flags_query = tep_db_query("describe " . TABLE_ORDERS_STATUS . " public_flag");
+            $flags_query = tep_db_query("describe " . TABLE_ORDERS_STATUS . " public_flag");
             if (tep_db_num_rows($flags_query) == 1) {
               foreach ($languages as $lang)
               {
@@ -607,10 +607,8 @@ class inpay
               foreach ($languages as $lang)
               {
                 tep_db_query("insert into ".TABLE_ORDERS_STATUS." (orders_status_id, language_id, orders_status_name) values ('".$status_id."', '".$lang['id']."', "."'".$order_status."')");
-              }	
+              }
             }
-			
-            
         } else
         {
             $check = tep_db_fetch_array($check_query);
@@ -624,19 +622,18 @@ class inpay
         $sum_too_low_status_id = $this->set_order_status('Sum too low [inpay]', true);
         $completed_status_id = $this->set_order_status('Completed [inpay]', true);
 
-		$sort_order = 0;
+        $sort_order = 0;
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable inpay on your webshop?', 'MODULE_PAYMENT_INPAY_STATUS', 'False', '', '6', '".$sort_order++."', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Gateway Server', 'MODULE_PAYMENT_INPAY_GATEWAY_SERVER', 'Production', 'Use the testing or production gateway server for transactions', '6', '".$sort_order++."', 'tep_cfg_select_option(array(\'Production\', \'Test\'), ', now())");
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Your merchant id', 'MODULE_PAYMENT_INPAY_MERCHANT_ID', '', 'Your merchant unique identifier (supplied by inpay)', '6', '".$sort_order++."', now())");
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Your secret key', 'MODULE_PAYMENT_INPAY_SECRET_KEY', '', 'Your secret key (supplied by inpay)', '6', '".$sort_order++."', now())");
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Flow Layout', 'MODULE_PAYMENT_INPAY_FLOW_LAYOUT', 'multi_page', 'Layout for the buyer flow', '6', '".$sort_order++."', now())");
-        
+
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Decrease stock on payment creation', 'MODULE_PAYMENT_INPAY_DECREASE_STOCK_ON_CREATION', 'False', 'Do you want to decrease stock upon payment creation?', '6', '".$sort_order++."', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Debug E-Mail Address', 'MODULE_PAYMENT_INPAY_DEBUG_EMAIL', '', 'All parameters of an Invalid IPN notification will be sent to this email address if one is entered.', '6', '".$sort_order++."', now())");
-        
-        
+
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, use_function, set_function, date_added) values ('Payment Zone', 'MODULE_PAYMENT_INPAY_ZONE', '0', 'If a zone is selected, only enable this payment method for that zone.', '6', '".$sort_order++."', 'tep_get_zone_class_title', 'tep_cfg_pull_down_zone_classes(', now())");
-        
+
         //tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('E-Mail Address', 'MODULE_PAYMENT_INPAY_ID', '', 'The inpay seller e-mail address to accept payments for', '6', '4', now())");
         tep_db_query("insert into ".TABLE_CONFIGURATION." (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort order of display.', 'MODULE_PAYMENT_INPAY_SORT_ORDER', '0', 'Sort order of display. Lowest is displayed first.', '6', '".$sort_order++."', now())");
 
@@ -658,7 +655,7 @@ class inpay
 
     function keys()
     {
-    	//'MODULE_PAYMENT_INPAY_ID', 
+        //'MODULE_PAYMENT_INPAY_ID',
         return array('MODULE_PAYMENT_INPAY_STATUS', 'MODULE_PAYMENT_INPAY_GATEWAY_SERVER', 'MODULE_PAYMENT_INPAY_MERCHANT_ID', 'MODULE_PAYMENT_INPAY_SECRET_KEY', 'MODULE_PAYMENT_INPAY_FLOW_LAYOUT', 'MODULE_PAYMENT_INPAY_DECREASE_STOCK_ON_CREATION', 'MODULE_PAYMENT_INPAY_DEBUG_EMAIL', 'MODULE_PAYMENT_INPAY_ZONE', 'MODULE_PAYMENT_INPAY_SORT_ORDER', 'MODULE_PAYMENT_INPAY_CREATE_ORDER_STATUS_ID', 'MODULE_PAYMENT_INPAY_SUM_TOO_LOW_ORDER_STATUS_ID', 'MODULE_PAYMENT_INPAY_COMP_ORDER_STATUS_ID');
     }
 
@@ -684,7 +681,6 @@ class inpay
     //
     function calcInpayMd5Key($order)
     {
-    	
         $sk = MODULE_PAYMENT_INPAY_SECRET_KEY;
         $q = http_build_query( array ("merchant_id"=>$order['merchant_id'],
         "order_id"=>$order['order_id'],

--- a/catalog/includes/modules/payment/moneybookers.php
+++ b/catalog/includes/modules/payment/moneybookers.php
@@ -98,15 +98,7 @@
     }
 
     function pre_confirmation_check() {
-      global $cartID, $cart;
-
-      if (empty($cart->cartID)) {
-        $cartID = $cart->cartID = $cart->generate_cart_id();
-      }
-
-      if (!tep_session_is_registered('cartID')) {
-        tep_session_register('cartID');
-      }
+      return false;
     }
 
     function _prepareOrder() {
@@ -115,12 +107,12 @@
       $insert_order = false;
 
       if (tep_session_is_registered($this->_mbcartID)) {
-        $order_id = substr($GLOBALS[$this->_mbcartID], strpos($GLOBALS[$this->_mbcartID], '-')+1);
+        list($cart_string, $order_id) = explode($GLOBALS[$this->_mbcartID], '-', 2);
 
         $curr_check = tep_db_query("select currency from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
         $curr = tep_db_fetch_array($curr_check);
 
-        if ( ($curr['currency'] != $order->info['currency']) || ($cartID != substr($GLOBALS[$this->_mbcartID], 0, strlen($cartID))) ) {
+        if ( ($curr['currency'] != $order->info['currency']) || ($cart_string != $cart->as_string()) ) {
           $check_query = tep_db_query('select orders_id from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '" limit 1');
 
           if (tep_db_num_rows($check_query) < 1) {
@@ -271,7 +263,7 @@
           }
         }
 
-        $GLOBALS[$this->_mbcartID] = $cartID . '-' . $insert_id;
+        $GLOBALS[$this->_mbcartID] = $cart->as_string() . '-' . $insert_id;
         tep_session_register($this->_mbcartID);
       }
     }

--- a/catalog/includes/modules/payment/paypal_standard.php
+++ b/catalog/includes/modules/payment/paypal_standard.php
@@ -91,183 +91,173 @@
     }
 
     function pre_confirmation_check() {
-      global $cartID, $cart;
-
-      if (empty($cart->cartID)) {
-        $cartID = $cart->cartID = $cart->generate_cart_id();
-      }
-
-      if (!tep_session_is_registered('cartID')) {
-        tep_session_register('cartID');
-      }
+      return false;
     }
 
     function confirmation() {
-      global $cartID, $cart_PayPal_Standard_ID, $customer_id, $languages_id, $order, $order_total_modules;
+      global $cart, $cart_PayPal_Standard_ID, $customer_id, $languages_id, $order, $order_total_modules;
 
-      if (tep_session_is_registered('cartID')) {
-        $insert_order = false;
+      $insert_order = false;
 
-        if (tep_session_is_registered('cart_PayPal_Standard_ID')) {
-          $order_id = substr($cart_PayPal_Standard_ID, strpos($cart_PayPal_Standard_ID, '-')+1);
+      if (tep_session_is_registered('cart_PayPal_Standard_ID')) {
+        list($cart_string, $order_id) = explode($cart_PayPal_Standard_ID, '-', 2);
 
-          $curr_check = tep_db_query("select currency from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
-          $curr = tep_db_fetch_array($curr_check);
+        $curr_check = tep_db_query("select currency from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
+        $curr = tep_db_fetch_array($curr_check);
 
-          if ( ($curr['currency'] != $order->info['currency']) || ($cartID != substr($cart_PayPal_Standard_ID, 0, strlen($cartID))) ) {
-            $check_query = tep_db_query('select orders_id from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '" limit 1');
+        if ( ($curr['currency'] != $order->info['currency']) || ($cart_string != $cart->as_string()) ) {
+          $check_query = tep_db_query('select orders_id from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '" limit 1');
 
-            if (tep_db_num_rows($check_query) < 1) {
-              tep_db_query('delete from ' . TABLE_ORDERS . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_TOTAL . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . ' where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS_DOWNLOAD . ' where orders_id = "' . (int)$order_id . '"');
-            }
-
-            $insert_order = true;
+          if (tep_db_num_rows($check_query) < 1) {
+            tep_db_query('delete from ' . TABLE_ORDERS . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_TOTAL . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . ' where orders_id = "' . (int)$order_id . '"');
+            tep_db_query('delete from ' . TABLE_ORDERS_PRODUCTS_DOWNLOAD . ' where orders_id = "' . (int)$order_id . '"');
           }
-        } else {
+
           $insert_order = true;
         }
+      } else {
+        $insert_order = true;
+      }
 
-        if ($insert_order == true) {
-          $order_totals = array();
-          if (is_array($order_total_modules->modules)) {
-            reset($order_total_modules->modules);
-            while (list(, $value) = each($order_total_modules->modules)) {
-              $class = substr($value, 0, strrpos($value, '.'));
-              if ($GLOBALS[$class]->enabled) {
-                for ($i=0, $n=sizeof($GLOBALS[$class]->output); $i<$n; $i++) {
-                  if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text'])) {
-                    $order_totals[] = array('code' => $GLOBALS[$class]->code,
-                                            'title' => $GLOBALS[$class]->output[$i]['title'],
-                                            'text' => $GLOBALS[$class]->output[$i]['text'],
-                                            'value' => $GLOBALS[$class]->output[$i]['value'],
-                                            'sort_order' => $GLOBALS[$class]->sort_order);
-                  }
+      if ($insert_order == true) {
+        $order_totals = array();
+        if (is_array($order_total_modules->modules)) {
+          reset($order_total_modules->modules);
+          while (list(, $value) = each($order_total_modules->modules)) {
+            $class = substr($value, 0, strrpos($value, '.'));
+            if ($GLOBALS[$class]->enabled) {
+              for ($i=0, $n=sizeof($GLOBALS[$class]->output); $i<$n; $i++) {
+                if (tep_not_null($GLOBALS[$class]->output[$i]['title']) && tep_not_null($GLOBALS[$class]->output[$i]['text'])) {
+                  $order_totals[] = array('code' => $GLOBALS[$class]->code,
+                                          'title' => $GLOBALS[$class]->output[$i]['title'],
+                                          'text' => $GLOBALS[$class]->output[$i]['text'],
+                                          'value' => $GLOBALS[$class]->output[$i]['value'],
+                                          'sort_order' => $GLOBALS[$class]->sort_order);
                 }
               }
             }
           }
+        }
 
-          $sql_data_array = array('customers_id' => $customer_id,
-                                  'customers_name' => $order->customer['firstname'] . ' ' . $order->customer['lastname'],
-                                  'customers_company' => $order->customer['company'],
-                                  'customers_street_address' => $order->customer['street_address'],
-                                  'customers_suburb' => $order->customer['suburb'],
-                                  'customers_city' => $order->customer['city'],
-                                  'customers_postcode' => $order->customer['postcode'],
-                                  'customers_state' => $order->customer['state'],
-                                  'customers_country' => $order->customer['country']['title'],
-                                  'customers_telephone' => $order->customer['telephone'],
-                                  'customers_email_address' => $order->customer['email_address'],
-                                  'customers_address_format_id' => $order->customer['format_id'],
-                                  'delivery_name' => $order->delivery['firstname'] . ' ' . $order->delivery['lastname'],
-                                  'delivery_company' => $order->delivery['company'],
-                                  'delivery_street_address' => $order->delivery['street_address'],
-                                  'delivery_suburb' => $order->delivery['suburb'],
-                                  'delivery_city' => $order->delivery['city'],
-                                  'delivery_postcode' => $order->delivery['postcode'],
-                                  'delivery_state' => $order->delivery['state'],
-                                  'delivery_country' => $order->delivery['country']['title'],
-                                  'delivery_address_format_id' => $order->delivery['format_id'],
-                                  'billing_name' => $order->billing['firstname'] . ' ' . $order->billing['lastname'],
-                                  'billing_company' => $order->billing['company'],
-                                  'billing_street_address' => $order->billing['street_address'],
-                                  'billing_suburb' => $order->billing['suburb'],
-                                  'billing_city' => $order->billing['city'],
-                                  'billing_postcode' => $order->billing['postcode'],
-                                  'billing_state' => $order->billing['state'],
-                                  'billing_country' => $order->billing['country']['title'],
-                                  'billing_address_format_id' => $order->billing['format_id'],
-                                  'payment_method' => $order->info['payment_method'],
-                                  'cc_type' => $order->info['cc_type'],
-                                  'cc_owner' => $order->info['cc_owner'],
-                                  'cc_number' => $order->info['cc_number'],
-                                  'cc_expires' => $order->info['cc_expires'],
-                                  'date_purchased' => 'now()',
-                                  'orders_status' => $order->info['order_status'],
-                                  'currency' => $order->info['currency'],
-                                  'currency_value' => $order->info['currency_value']);
+        $sql_data_array = array('customers_id' => $customer_id,
+                                'customers_name' => $order->customer['firstname'] . ' ' . $order->customer['lastname'],
+                                'customers_company' => $order->customer['company'],
+                                'customers_street_address' => $order->customer['street_address'],
+                                'customers_suburb' => $order->customer['suburb'],
+                                'customers_city' => $order->customer['city'],
+                                'customers_postcode' => $order->customer['postcode'],
+                                'customers_state' => $order->customer['state'],
+                                'customers_country' => $order->customer['country']['title'],
+                                'customers_telephone' => $order->customer['telephone'],
+                                'customers_email_address' => $order->customer['email_address'],
+                                'customers_address_format_id' => $order->customer['format_id'],
+                                'delivery_name' => $order->delivery['firstname'] . ' ' . $order->delivery['lastname'],
+                                'delivery_company' => $order->delivery['company'],
+                                'delivery_street_address' => $order->delivery['street_address'],
+                                'delivery_suburb' => $order->delivery['suburb'],
+                                'delivery_city' => $order->delivery['city'],
+                                'delivery_postcode' => $order->delivery['postcode'],
+                                'delivery_state' => $order->delivery['state'],
+                                'delivery_country' => $order->delivery['country']['title'],
+                                'delivery_address_format_id' => $order->delivery['format_id'],
+                                'billing_name' => $order->billing['firstname'] . ' ' . $order->billing['lastname'],
+                                'billing_company' => $order->billing['company'],
+                                'billing_street_address' => $order->billing['street_address'],
+                                'billing_suburb' => $order->billing['suburb'],
+                                'billing_city' => $order->billing['city'],
+                                'billing_postcode' => $order->billing['postcode'],
+                                'billing_state' => $order->billing['state'],
+                                'billing_country' => $order->billing['country']['title'],
+                                'billing_address_format_id' => $order->billing['format_id'],
+                                'payment_method' => $order->info['payment_method'],
+                                'cc_type' => $order->info['cc_type'],
+                                'cc_owner' => $order->info['cc_owner'],
+                                'cc_number' => $order->info['cc_number'],
+                                'cc_expires' => $order->info['cc_expires'],
+                                'date_purchased' => 'now()',
+                                'orders_status' => $order->info['order_status'],
+                                'currency' => $order->info['currency'],
+                                'currency_value' => $order->info['currency_value']);
 
-          tep_db_perform(TABLE_ORDERS, $sql_data_array);
+        tep_db_perform(TABLE_ORDERS, $sql_data_array);
 
-          $insert_id = tep_db_insert_id();
+        $insert_id = tep_db_insert_id();
 
-          for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
-            $sql_data_array = array('orders_id' => $insert_id,
-                                    'title' => $order_totals[$i]['title'],
-                                    'text' => $order_totals[$i]['text'],
-                                    'value' => $order_totals[$i]['value'],
-                                    'class' => $order_totals[$i]['code'],
-                                    'sort_order' => $order_totals[$i]['sort_order']);
+        for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {
+          $sql_data_array = array('orders_id' => $insert_id,
+                                  'title' => $order_totals[$i]['title'],
+                                  'text' => $order_totals[$i]['text'],
+                                  'value' => $order_totals[$i]['value'],
+                                  'class' => $order_totals[$i]['code'],
+                                  'sort_order' => $order_totals[$i]['sort_order']);
 
-            tep_db_perform(TABLE_ORDERS_TOTAL, $sql_data_array);
-          }
+          tep_db_perform(TABLE_ORDERS_TOTAL, $sql_data_array);
+        }
 
-          for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
-            $sql_data_array = array('orders_id' => $insert_id,
-                                    'products_id' => tep_get_prid($order->products[$i]['id']),
-                                    'products_model' => $order->products[$i]['model'],
-                                    'products_name' => $order->products[$i]['name'],
-                                    'products_price' => $order->products[$i]['price'],
-                                    'final_price' => $order->products[$i]['final_price'],
-                                    'products_tax' => $order->products[$i]['tax'],
-                                    'products_quantity' => $order->products[$i]['qty']);
+        for ($i=0, $n=sizeof($order->products); $i<$n; $i++) {
+          $sql_data_array = array('orders_id' => $insert_id,
+                                  'products_id' => tep_get_prid($order->products[$i]['id']),
+                                  'products_model' => $order->products[$i]['model'],
+                                  'products_name' => $order->products[$i]['name'],
+                                  'products_price' => $order->products[$i]['price'],
+                                  'final_price' => $order->products[$i]['final_price'],
+                                  'products_tax' => $order->products[$i]['tax'],
+                                  'products_quantity' => $order->products[$i]['qty']);
 
-            tep_db_perform(TABLE_ORDERS_PRODUCTS, $sql_data_array);
+          tep_db_perform(TABLE_ORDERS_PRODUCTS, $sql_data_array);
 
-            $order_products_id = tep_db_insert_id();
+          $order_products_id = tep_db_insert_id();
 
-            $attributes_exist = '0';
-            if (isset($order->products[$i]['attributes'])) {
-              $attributes_exist = '1';
-              for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
-                if (DOWNLOAD_ENABLED == 'true') {
-                  $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
-                                       from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa
-                                       left join " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
-                                       on pa.products_attributes_id=pad.products_attributes_id
-                                       where pa.products_id = '" . $order->products[$i]['id'] . "'
-                                       and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "'
-                                       and pa.options_id = popt.products_options_id
-                                       and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "'
-                                       and pa.options_values_id = poval.products_options_values_id
-                                       and popt.language_id = '" . $languages_id . "'
-                                       and poval.language_id = '" . $languages_id . "'";
-                  $attributes = tep_db_query($attributes_query);
-                } else {
-                  $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa where pa.products_id = '" . $order->products[$i]['id'] . "' and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
-                }
-                $attributes_values = tep_db_fetch_array($attributes);
+          $attributes_exist = '0';
+          if (isset($order->products[$i]['attributes'])) {
+            $attributes_exist = '1';
+            for ($j=0, $n2=sizeof($order->products[$i]['attributes']); $j<$n2; $j++) {
+              if (DOWNLOAD_ENABLED == 'true') {
+                $attributes_query = "select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix, pad.products_attributes_maxdays, pad.products_attributes_maxcount , pad.products_attributes_filename
+                                     from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa
+                                     left join " . TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD . " pad
+                                     on pa.products_attributes_id=pad.products_attributes_id
+                                     where pa.products_id = '" . $order->products[$i]['id'] . "'
+                                     and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "'
+                                     and pa.options_id = popt.products_options_id
+                                     and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "'
+                                     and pa.options_values_id = poval.products_options_values_id
+                                     and popt.language_id = '" . $languages_id . "'
+                                     and poval.language_id = '" . $languages_id . "'";
+                $attributes = tep_db_query($attributes_query);
+              } else {
+                $attributes = tep_db_query("select popt.products_options_name, poval.products_options_values_name, pa.options_values_price, pa.price_prefix from " . TABLE_PRODUCTS_OPTIONS . " popt, " . TABLE_PRODUCTS_OPTIONS_VALUES . " poval, " . TABLE_PRODUCTS_ATTRIBUTES . " pa where pa.products_id = '" . $order->products[$i]['id'] . "' and pa.options_id = '" . $order->products[$i]['attributes'][$j]['option_id'] . "' and pa.options_id = popt.products_options_id and pa.options_values_id = '" . $order->products[$i]['attributes'][$j]['value_id'] . "' and pa.options_values_id = poval.products_options_values_id and popt.language_id = '" . $languages_id . "' and poval.language_id = '" . $languages_id . "'");
+              }
+              $attributes_values = tep_db_fetch_array($attributes);
 
+              $sql_data_array = array('orders_id' => $insert_id,
+                                      'orders_products_id' => $order_products_id,
+                                      'products_options' => $attributes_values['products_options_name'],
+                                      'products_options_values' => $attributes_values['products_options_values_name'],
+                                      'options_values_price' => $attributes_values['options_values_price'],
+                                      'price_prefix' => $attributes_values['price_prefix']);
+
+              tep_db_perform(TABLE_ORDERS_PRODUCTS_ATTRIBUTES, $sql_data_array);
+
+              if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
                 $sql_data_array = array('orders_id' => $insert_id,
                                         'orders_products_id' => $order_products_id,
-                                        'products_options' => $attributes_values['products_options_name'],
-                                        'products_options_values' => $attributes_values['products_options_values_name'],
-                                        'options_values_price' => $attributes_values['options_values_price'],
-                                        'price_prefix' => $attributes_values['price_prefix']);
+                                        'orders_products_filename' => $attributes_values['products_attributes_filename'],
+                                        'download_maxdays' => $attributes_values['products_attributes_maxdays'],
+                                        'download_count' => $attributes_values['products_attributes_maxcount']);
 
-                tep_db_perform(TABLE_ORDERS_PRODUCTS_ATTRIBUTES, $sql_data_array);
-
-                if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
-                  $sql_data_array = array('orders_id' => $insert_id,
-                                          'orders_products_id' => $order_products_id,
-                                          'orders_products_filename' => $attributes_values['products_attributes_filename'],
-                                          'download_maxdays' => $attributes_values['products_attributes_maxdays'],
-                                          'download_count' => $attributes_values['products_attributes_maxcount']);
-
-                  tep_db_perform(TABLE_ORDERS_PRODUCTS_DOWNLOAD, $sql_data_array);
-                }
+                tep_db_perform(TABLE_ORDERS_PRODUCTS_DOWNLOAD, $sql_data_array);
               }
             }
           }
-
-          $cart_PayPal_Standard_ID = $cartID . '-' . $insert_id;
-          tep_session_register('cart_PayPal_Standard_ID');
         }
+
+        $cart_PayPal_Standard_ID = $cart->as_string() . '-' . $insert_id;
+        tep_session_register('cart_PayPal_Standard_ID');
       }
 
       return false;

--- a/catalog/includes/modules/payment/rbsworldpay_hosted.php
+++ b/catalog/includes/modules/payment/rbsworldpay_hosted.php
@@ -91,29 +91,21 @@
     }
 
     function pre_confirmation_check() {
-      global $cartID, $cart;
-
-      if (empty($cart->cartID)) {
-        $cartID = $cart->cartID = $cart->generate_cart_id();
-      }
-
-      if (!tep_session_is_registered('cartID')) {
-        tep_session_register('cartID');
-      }
+      return false;
     }
 
     function confirmation() {
-      global $cartID, $cart_RBS_Worldpay_Hosted_ID, $customer_id, $languages_id, $order, $order_total_modules;
+      global $cart, $cart_RBS_Worldpay_Hosted_ID, $customer_id, $languages_id, $order, $order_total_modules;
 
       $insert_order = false;
 
       if (tep_session_is_registered('cart_RBS_Worldpay_Hosted_ID')) {
-        $order_id = substr($cart_RBS_Worldpay_Hosted_ID, strpos($cart_RBS_Worldpay_Hosted_ID, '-')+1);
+        list($cart_string, $order_id) = explode($cart_RBS_Worldpay_Hosted_ID, '-', 2);
 
         $curr_check = tep_db_query("select currency from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
         $curr = tep_db_fetch_array($curr_check);
 
-        if ( ($curr['currency'] != $order->info['currency']) || ($cartID != substr($cart_RBS_Worldpay_Hosted_ID, 0, strlen($cartID))) ) {
+        if ( ($curr['currency'] != $order->info['currency']) || ($cart_string != $cart->as_string()) ) {
           $check_query = tep_db_query('select orders_id from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '" limit 1');
 
           if (tep_db_num_rows($check_query) < 1) {
@@ -264,7 +256,7 @@
           }
         }
 
-        $cart_RBS_Worldpay_Hosted_ID = $cartID . '-' . $insert_id;
+        $cart_RBS_Worldpay_Hosted_ID = $cart->as_string() . '-' . $insert_id;
         tep_session_register('cart_RBS_Worldpay_Hosted_ID');
       }
 

--- a/catalog/includes/modules/payment/sofortueberweisung_direct.php
+++ b/catalog/includes/modules/payment/sofortueberweisung_direct.php
@@ -276,9 +276,9 @@
       $order_id = substr($cart_Sofortueberweisung_Direct_ID, strpos($cart_Sofortueberweisung_Direct_ID, '-')+1);
 
       $parameter= array();
-      $parameter['kdnr']	= MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_KDNR;  // Repräsentiert Ihre Kundennummer bei der Sofortüberweisung
-      $parameter['projekt'] = MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_PROJEKT;  // Die verantwortliche Projektnummer bei der Sofortüberweisung, zu der die Zahlung gehört
-      $parameter['betrag'] = number_format($order->info['total'] * $currencies->get_value('EUR'), 2, '.','');  // Beziffert den Zahlungsbetrag, der an Sie übermittelt werden soll
+      $parameter['kdnr']	= MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_KDNR;  // ReprÃ¤sentiert Ihre Kundennummer bei der SofortÃ¼berweisung
+      $parameter['projekt'] = MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_PROJEKT;  // Die verantwortliche Projektnummer bei der SofortÃ¼berweisung, zu der die Zahlung gehÃ¶rt
+      $parameter['betrag'] = number_format($order->info['total'] * $currencies->get_value('EUR'), 2, '.','');  // Beziffert den Zahlungsbetrag, der an Sie Ã¼bermittelt werden soll
       $vzweck1 = str_replace('{{orderid}}', $order_id, MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_TEXT_V_ZWECK_1);
       $vzweck2 = str_replace('{{orderid}}', $order_id, MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_TEXT_V_ZWECK_2);
 
@@ -297,7 +297,7 @@
       $vzweck1 = str_replace('{{customer_email}}', $order->customer['email_address'], $vzweck1);
       $vzweck2 = str_replace('{{customer_email}}', $order->customer['email_address'], $vzweck2);
 
-      // Kürzen auf 27 Zeichen
+      // KÃ¼rzen auf 27 Zeichen
       $vzweck1 = substr($vzweck1, 0, 27);
       $vzweck2 = substr($vzweck2, 0, 27);
 
@@ -343,7 +343,7 @@
       global $$payment;
 
       $md5var4 = md5($HTTP_GET_VARS['sovar3'] . MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_CNT_PASSWORT);
-      // Statusupdate nur wenn keine Cartänderung vorgenommen
+      // Statusupdate nur wenn keine CartÃ¤nderung vorgenommen
       $order_total_integer = number_format($order->info['total'] * $currencies->get_value('EUR'), 2, '.','')*100;
       if ($order_total_integer < 1) {
         $order_total_integer = '000';
@@ -367,7 +367,7 @@
                                   'comments' => '');
 
           if (($md5var4 == $HTTP_GET_VARS['sovar4']) && ((int)$HTTP_GET_VARS['betrag_integer'] == (int)$order_total_integer)) {
-            $sql_data_array['comments'] = 'Zahlung durch Sofortüberweisung Weiter-Button/Weiterleitung bestätigt!';
+            $sql_data_array['comments'] = 'Zahlung durch SofortÃ¼berweisung Weiter-Button/Weiterleitung bestÃ¤tigt!';
           } else {
             $sql_data_array['comments'] = MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_TEXT_CHECK_ERROR . '\n' . ($HTTP_GET_VARS['betrag_integer']/100) . '!=' . ($order_total_integer/100);
           }
@@ -562,7 +562,7 @@
       $bna_passwort = (isset($HTTP_GET_VARS['bna_passwort']) && !empty($HTTP_GET_VARS['bna_passwort'])) ? tep_db_prepare_input($HTTP_GET_VARS['bna_passwort']) : '';
       $cnt_passwort = (isset($HTTP_GET_VARS['cnt_passwort']) && !empty($HTTP_GET_VARS['cnt_passwort'])) ? tep_db_prepare_input($HTTP_GET_VARS['cnt_passwort']) : '';
 
-      $check_query = tep_db_query("select orders_status_id from " . TABLE_ORDERS_STATUS . " where orders_status_name = 'Sofortüberweisung Vorbereitung' limit 1");
+      $check_query = tep_db_query("select orders_status_id from " . TABLE_ORDERS_STATUS . " where orders_status_name = 'SofortÃ¼berweisung Vorbereitung' limit 1");
 
       if (tep_db_num_rows($check_query) < 1) {
         $status_query = tep_db_query("select max(orders_status_id) as status_id from " . TABLE_ORDERS_STATUS);
@@ -573,7 +573,7 @@
         $languages = tep_get_languages();
 
         for ($i=0, $n=sizeof($languages); $i<$n; $i++) {
-          tep_db_query("insert into " . TABLE_ORDERS_STATUS . " (orders_status_id, language_id, orders_status_name) values ('" . $status_id . "', '" . $languages[$i]['id'] . "', 'Sofortüberweisung Vorbereitung')");
+          tep_db_query("insert into " . TABLE_ORDERS_STATUS . " (orders_status_id, language_id, orders_status_name) values ('" . $status_id . "', '" . $languages[$i]['id'] . "', 'SofortÃ¼berweisung Vorbereitung')");
         }
 
         $flags_query = tep_db_query("describe " . TABLE_ORDERS_STATUS . " public_flag");
@@ -586,17 +586,17 @@
         $status_id = $check['orders_status_id'];
       }
 
-      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Sofortüberweisung direkter Modus aktivieren', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_STATUS', 'True', 'Bezahlung per Sofortüberweisung acceptieren?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now());");
-      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Kundennummer:', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_KDNR', '" . (int)$kdnr . "', 'Ihre Kundennummer bei der Sofortüberweisung', '6', '1', now());");
-      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Projektnummer:', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_PROJEKT', '" . (int)$projekt . "', 'Die verantwortliche Projektnummer bei der Sofortüberweisung, zu der die Zahlung gehört', '6', '1', now());");
-      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Input-Passwort:', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_INPUT_PASSWORT', '" . tep_db_input($input_passwort) . "', 'Das Input-Passwort (unter Nicht änderbare Parameter / Input-Passwort)', '6', '1', now());");
+      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('SofortÃ¼berweisung direkter Modus aktivieren', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_STATUS', 'True', 'Bezahlung per SofortÃ¼berweisung acceptieren?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now());");
+      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Kundennummer:', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_KDNR', '" . (int)$kdnr . "', 'Ihre Kundennummer bei der SofortÃ¼berweisung', '6', '1', now());");
+      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Projektnummer:', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_PROJEKT', '" . (int)$projekt . "', 'Die verantwortliche Projektnummer bei der SofortÃ¼berweisung, zu der die Zahlung gehÃ¶rt', '6', '1', now());");
+      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Input-Passwort:', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_INPUT_PASSWORT', '" . tep_db_input($input_passwort) . "', 'Das Input-Passwort (unter Nicht Ã¤nderbare Parameter / Input-Passwort)', '6', '1', now());");
       tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Benachrichtigung-Passwort:', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_BNA_PASSWORT', '" . tep_db_input($bna_passwort) . "', 'Das Benachrichtigung-Passwort (unter Benachrichtigungen festlegen)', '6', '1', now());");
       tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Contentpasswort:', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_CNT_PASSWORT', '" . tep_db_input($cnt_passwort) . "', 'Das Contentpasswort (unter Content-Passwort)', '6', '1', now());");
       tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort order of display.', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_SORT_ORDER', '0', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
       tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, use_function, set_function, date_added) values ('Payment Zone', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_ZONE', '0', 'If a zone is selected, only enable this payment method for that zone.', '6', '2', 'tep_get_zone_class_title', 'tep_cfg_pull_down_zone_classes(', now())");
       tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, use_function, date_added) values ('Set Preparing Order Status', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_PREPARE_ORDER_STATUS_ID', '" . (int)$status_id . "', 'Order Status vor Eingang Bestellung', '6', '0', 'tep_cfg_pull_down_order_statuses(', 'tep_get_order_status_name', now())");
       tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, use_function, date_added) values ('Set Order Status', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_ORDER_STATUS_ID', '0', 'Order Status nach Eingang Bestellung', '6', '0', 'tep_cfg_pull_down_order_statuses(', 'tep_get_order_status_name', now())");
-      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Store Transactiondetails', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_STORE_TRANSACTION_DETAILS', 'False', 'Transactionsdetails bei Benachrichtigung in das Kommentarfeld speichern (zum debuggen, ist für Kunden via Konto sichtbar)', '6', '2', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now());");
+      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Store Transactiondetails', 'MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_STORE_TRANSACTION_DETAILS', 'False', 'Transactionsdetails bei Benachrichtigung in das Kommentarfeld speichern (zum debuggen, ist fÃ¼r Kunden via Konto sichtbar)', '6', '2', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now());");
     }
 
     function remove() {

--- a/catalog/includes/modules/payment/sofortueberweisung_direct.php
+++ b/catalog/includes/modules/payment/sofortueberweisung_direct.php
@@ -89,30 +89,21 @@
     }
 
     function pre_confirmation_check() {
-      global $cartID, $cart;
-
-      // We need the cartID
-      if (empty($cart->cartID)) {
-        $cartID = $cart->cartID = $cart->generate_cart_id();
-      }
-
-      if (!tep_session_is_registered('cartID')) {
-        tep_session_register('cartID');
-      }
+      return false;
     }
 
     function confirmation() {
-      global $cartID, $cart_Sofortueberweisung_Direct_ID, $customer_id, $languages_id, $order, $order_total_modules;
+      global $cart, $cart_Sofortueberweisung_Direct_ID, $customer_id, $languages_id, $order, $order_total_modules;
 
       $insert_order = false;
 
       if (tep_session_is_registered('cart_Sofortueberweisung_Direct_ID')) {
-        $order_id = substr($cart_Sofortueberweisung_Direct_ID, strpos($cart_Sofortueberweisung_Direct_ID, '-')+1);
+        list($cart_string, $order_id) = explode($cart_Sofortueberweisung_Direct_ID, '-', 2);
 
         $curr_check = tep_db_query("select currency from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
         $curr = tep_db_fetch_array($curr_check);
 
-        if ( ($curr['currency'] != $order->info['currency']) || ($cartID != substr($cart_Sofortueberweisung_Direct_ID, 0, strlen($cartID))) ) {
+        if ( ($curr['currency'] != $order->info['currency']) || ($cart_string != $cart->as_string()) ) {
           $check_query = tep_db_query('select orders_id from ' . TABLE_ORDERS_STATUS_HISTORY . ' where orders_id = "' . (int)$order_id . '" limit 1');
 
           if (tep_db_num_rows($check_query) < 1) {
@@ -263,7 +254,7 @@
           }
         }
 
-        $cart_Sofortueberweisung_Direct_ID = $cartID . '-' . $insert_id;
+        $cart_Sofortueberweisung_Direct_ID = $cart->as_string() . '-' . $insert_id;
         tep_session_register('cart_Sofortueberweisung_Direct_ID');
       }
 
@@ -273,7 +264,7 @@
     function process_button() {
       global $order, $cart, $customer_id, $currencies, $cart_Sofortueberweisung_Direct_ID;
 
-      $order_id = substr($cart_Sofortueberweisung_Direct_ID, strpos($cart_Sofortueberweisung_Direct_ID, '-')+1);
+      list($cart_string, $order_id) = explode($cart_Sofortueberweisung_Direct_ID, '-', 2);
 
       $parameter= array();
       $parameter['kdnr']	= MODULE_PAYMENT_SOFORTUEBERWEISUNG_DIRECT_KDNR;  // Repräsentiert Ihre Kundennummer bei der Sofortüberweisung
@@ -307,7 +298,7 @@
       $parameter['kunden_var_0'] = tep_output_string($order_id);  // Eindeutige Identifikation der Zahlung, z.B. Session ID oder Auftragsnummer.
       $parameter['kunden_var_1'] = tep_output_string($customer_id);
       $parameter['kunden_var_2'] = tep_output_string(tep_session_id());
-      $parameter['kunden_var_3'] = tep_output_string($cart->cartID);
+      $parameter['kunden_var_3'] = tep_output_string($cart_string);
       $parameter['kunden_var_4'] = '';
       $parameter['kunden_var_5'] = '';
       // $parameter['Partner'] = '';


### PR DESCRIPTION
Using two browser tabs a user can modify her cart after selecting a shipping/payment module, thus for example get a lower shipping rate. Steps to reproduce:
- install a clean copy of osC 2.3 (tested with Apache/2.2.16, PHP 5.2.17 and 5.3.3);
- enable "Per Item" shipping through admin;
- in one tab: add something to the cart, click checkout, register, select per item shipping, continue, but don't select payment;
- in a second tab: add something to the cart (*and visit shipping selection = click checkout);
- in the first tab: continue to confirmation -- the item added in the second tab does not increase shipping cost, checkout does not reset.

The `$cartID` prevention added some time ago is ineffective due to a couple of reasons:
- firstly, with `register_globals` disabled both `$cartID` and `$cart->cartID` end up pointing to the same memory -- they always match; this is due to some interplay of registering a variable before setting it and `session.bug_compat_42` (which may or may not be a PHP bug), this can be demonstrated with a small example:

``` php
<?php
    // test-1.php
    // assumption: register_globals is off (.htaccess: php_value register_globals 0)
    ini_set('session.bug_compat_42', 1);
    session_start();

    $_SESSION['a'] = null;
    $a = 1; // $cart->cartID

    $_SESSION['b'] = null;
    $b = $a; // $cartID
?>
```

``` php
<?php
    // test-2.php
    session_start();

    $_SESSION['a'] = 2;

    var_dump($_SESSION); // both $a and $b are equal to 2
?>
```
- secondly, the `$cartID` is equated to `$cart->cartID` on every request to `checkout_shipping.php`, without submitting the form -- so after adding the product to the cart, view the shipping selection page in the second tab, and continue in the first tab (with the original shipping cost; this may be used with `register_globals` on).
- thirdly, the `$cart->cartID` is not reset in the `shopping_cart->update_quantity`, which is not called directly in a clean osC, but it's neither marked as private, so an uninformed developer may use it in a module or own code.

There are various ways to amend this, the code attached is my quick attempt at it -- there are some caveats:
- unfortunately it's all done against osC 2, I've not even tried to verify the issue with 3.x;
- only the first commit contains the actual fixes;
- payment modules changes are completely untested;
- all the flaws can probably be fixed in some less intrusive way.

I'd say this issue is of a lesser concern, but we've observed such a cart modification in a production store (most probably just a coincidence, rather than a willful exploit), so maybe it's worth fixing -- this way or another. Sorry for this lack of testing and the careless attitude, but maybe someone more into the system will be able to make something of it .
