### PR TITLE
Address override during checkout

### DIFF
--- a/catalog/checkout_payment_address.php
+++ b/catalog/checkout_payment_address.php
@@ -175,10 +175,10 @@
       } else {
         tep_session_unregister('billto');
       }
-// no addresses to select from - customer decided to keep the current assigned address
     } else {
       if (!tep_session_is_registered('billto')) tep_session_register('billto');
       $billto = $customer_default_address_id;
+      if (tep_session_is_registered('payment')) tep_session_unregister('payment');
 
       tep_redirect(tep_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
     }

--- a/catalog/checkout_shipping_address.php
+++ b/catalog/checkout_shipping_address.php
@@ -191,6 +191,7 @@
     } else {
       if (!tep_session_is_registered('sendto')) tep_session_register('sendto');
       $sendto = $customer_default_address_id;
+      if (tep_session_is_registered('shipping')) tep_session_unregister('shipping');
 
       tep_redirect(tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'));
     }


### PR DESCRIPTION
Some shipping modules rely on fixing a shipping address (e.g. self-collection, delivery to an automaton) or calculate a fee based on the address. Using two browser tabs a user can however change the address (to her default address) past selecting a shipping method.

This can be done by selecting a shipping method in one tab, opening address change page in a second tab, continuing in the first tab, and submitting the address change form (second tab) without selecting anything. Shipping is neither reset nor updated.

The proposed fix resets shipping / payment after submitting the address change form without any selection (other cases are already handled properly).
