### PR TITLE
Rename the folder to the new admin name to write a configuration file

### DIFF
--- a/catalog/install/templates/pages/install_4.php
+++ b/catalog/install/templates/pages/install_4.php
@@ -190,16 +190,17 @@
   }
 
   $file_contents .= '?>';
+  
+  if ($admin_folder != 'admin') {
+    @rename($dir_fs_document_root . 'admin', $dir_fs_document_root . $admin_folder);
+  }  
 
-  $fp = fopen($dir_fs_document_root . 'admin/includes/configure.php', 'w');
+  $fp = fopen($dir_fs_document_root . $admin_folder . '/includes/configure.php', 'w');
   fputs($fp, $file_contents);
   fclose($fp);
 
-  @chmod($dir_fs_document_root . 'admin/includes/configure.php', 0644);
+  @chmod($dir_fs_document_root . $admin_folder . '/includes/configure.php', 0644);
 
-  if ($admin_folder != 'admin') {
-    @rename($dir_fs_document_root . 'admin', $dir_fs_document_root . $admin_folder);
-  }
 ?>
 
     <p>The installation and configuration was successful!</p>


### PR DESCRIPTION
Rename the folder to the new admin name to write a configuration file otherwise get the Warning: fopen (\admin\includes\configure.php): failed to open stream: No such file or directory in \install\templates\pages\install_4.php on line 197
