### PR TITLE
Fix issues with missing order total modules

### DIFF
--- a/catalog/admin/modules.php
+++ b/catalog/admin/modules.php
@@ -5,12 +5,13 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2010 osCommerce
+  Copyright (c) 2013 osCommerce
 
   Released under the GNU General Public License
 */
 
   require('includes/application_top.php');
+
   $set = (isset($HTTP_GET_VARS['set']) ? $HTTP_GET_VARS['set'] : '');
 
   $modules = $cfgModules->getAll();
@@ -45,19 +46,29 @@
           include($module_directory . $class . $file_extension);
           $module = new $class;
           if ($action == 'install') {
+            if ($module->check() > 0) { // remove module if already installed
+              $module->remove();
+            }
+
             $module->install();
 
             $modules_installed = explode(';', constant($module_key));
-            $modules_installed[] = $class . $file_extension;
+
+            if (!in_array($class . $file_extension, $modules_installed)) {
+              $modules_installed[] = $class . $file_extension;
+            }
+
             tep_db_query("update " . TABLE_CONFIGURATION . " set configuration_value = '" . implode(';', $modules_installed) . "' where configuration_key = '" . $module_key . "'");
             tep_redirect(tep_href_link(FILENAME_MODULES, 'set=' . $set . '&module=' . $class));
           } elseif ($action == 'remove') {
             $module->remove();
 
             $modules_installed = explode(';', constant($module_key));
-            if (array_search($class . $file_extension, $modules_installed) !== false) { 
-               unset($modules_installed[array_search($class . $file_extension, $modules_installed)]);
-            } 
+
+            if (in_array($class . $file_extension, $modules_installed)) {
+              unset($modules_installed[array_search($class . $file_extension, $modules_installed)]);
+            }
+
             tep_db_query("update " . TABLE_CONFIGURATION . " set configuration_value = '" . implode(';', $modules_installed) . "' where configuration_key = '" . $module_key . "'");
             tep_redirect(tep_href_link(FILENAME_MODULES, 'set=' . $set));
           }
@@ -68,8 +79,10 @@
   }
 
   require(DIR_WS_INCLUDES . 'template_top.php');
+
   $modules_installed = (defined($module_key) ? explode(';', constant($module_key)) : array());
   $new_modules_counter = 0;
+
   $file_extension = substr($PHP_SELF, strrpos($PHP_SELF, '.'));
   $directory_array = array();
   if ($dir = @dir($module_directory)) {
@@ -177,7 +190,7 @@
       }
 ?>
                 <td class="dataTableContent"><?php echo $module->title; ?></td>
-                <td class="dataTableContent" align="right"><?php if (is_numeric($module->sort_order)) echo $module->sort_order; ?></td>
+                <td class="dataTableContent" align="right"><?php if (in_array($module->code . $file_extension, $modules_installed) && is_numeric($module->sort_order)) echo $module->sort_order; ?></td>
                 <td class="dataTableContent" align="right"><?php if (isset($mInfo) && is_object($mInfo) && ($class == $mInfo->code) ) { echo tep_image(DIR_WS_IMAGES . 'icon_arrow_right.gif'); } else { echo '<a href="' . tep_href_link(FILENAME_MODULES, 'set=' . $set . (isset($HTTP_GET_VARS['list']) ? '&list=new' : '') . '&module=' . $class) . '">' . tep_image(DIR_WS_IMAGES . 'icon_info.gif', IMAGE_ICON_INFO) . '</a>'; } ?>&nbsp;</td>
               </tr>
 <?php
@@ -223,9 +236,6 @@
   switch ($action) {
     case 'edit':
       $keys = '';
-      if (!isset($mInfo) || !is_array($mInfo->keys)) {
-        break; // won't work - you must remove first
-      }
       reset($mInfo->keys);
       while (list($key, $value) = each($mInfo->keys)) {
         $keys .= '<strong>' . $value['title'] . '</strong><br />' . $value['description'] . '<br />';
@@ -248,7 +258,7 @@
     default:
       $heading[] = array('text' => '<strong>' . $mInfo->title . '</strong>');
 
-      if ($mInfo->status > 0) {
+      if (in_array($mInfo->code . $file_extension, $modules_installed) && ($mInfo->status > 0)) {
         $keys = '';
         reset($mInfo->keys);
         while (list(, $value) = each($mInfo->keys)) {


### PR DESCRIPTION
Several problems can occur if you update your osCommerce database from a fresh version of the source without your old order total modules.  You will only see the order total module in the "Install Module" section.  But the trouble is, from there, if you try to edit, it won't work, and if you try to remove it will remove the wrong thing.  And you can wind up trying to add the module several times, which will put duplicate keys in your database.  This PR adds a fix for the remove problem so the right thing is removed, a workaround for the edit problem so the wrong thing isn't edited, and a fix for the duplicate key issue, by checking > 0 rather than == 1. 
