### PR TITLE
Prevent logo cache

### DIFF
--- a/catalog/admin/store_logo.php
+++ b/catalog/admin/store_logo.php
@@ -59,7 +59,7 @@
         </table></td>
       </tr>
       <tr>
-        <td><?php echo tep_image(HTTP_CATALOG_SERVER . DIR_WS_CATALOG_IMAGES . 'store_logo.png'); ?></td>
+        <td><?php echo tep_image(HTTP_CATALOG_SERVER . DIR_WS_CATALOG_IMAGES . 'store_logo.png?'. str_replace(array('.',' '),'', microtime())); ?>></td>
       </tr>
       <tr>
         <td><?php echo tep_draw_separator('pixel_trans.gif', '1', '10'); ?></td>


### PR DESCRIPTION
Most of the times the logo is cached so even though the image WAS updated, the browser won't show the change and the user will think it wasn't changed. Adding ?microtime at the end of the will force the browse to download the new logo.
