### PR TITLE
Only add line items if calculations match order total calculations

### DIFF
--- a/catalog/checkout_confirmation.php
+++ b/catalog/checkout_confirmation.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2010 osCommerce
+  Copyright (c) 2014 osCommerce
 
   Released under the GNU General Public License
 */
@@ -93,6 +93,10 @@
 <h1><?php echo HEADING_TITLE; ?></h1>
 
 <?php
+  if ($messageStack->size('checkout_confirmation') > 0) {
+    echo $messageStack->output('checkout_confirmation');
+  }
+
   if (isset($$payment->form_action_url)) {
     $form_action_url = $$payment->form_action_url;
   } else {

--- a/catalog/includes/languages/english/modules/payment/paypal_express.php
+++ b/catalog/includes/languages/english/modules/payment/paypal_express.php
@@ -37,4 +37,5 @@
 
   define('MODULE_PAYMENT_PAYPAL_EXPRESS_ERROR_NO_SHIPPING_AVAILABLE_TO_SHIPPING_ADDRESS', 'Shipping is currently not available for the selected shipping address. Please select or create a new shipping address to use with your purchase.');
   define('MODULE_PAYMENT_PAYPAL_EXPRESS_WARNING_LOCAL_LOGIN_REQUIRED', 'Please log into your account to verify the order.');
+  define('MODULE_PAYMENT_PAYPAL_EXPRESS_NOTICE_CHECKOUT_CONFIRMATION', 'Please review and confirm your order below. Your order will not be processed until it has been confirmed.');
 ?>


### PR DESCRIPTION
Include tax in shipping cost calculations and remove tax from order total calculations
Add order total module calculations to Instant Update
Increase Instant Update callback timeout to 6 seconds
Only add TAXAMT if DISPLAY_PRICE_WITH_TAX is false
Add message stack output to checkout confirmation page
If PayPal transaction total does not match order total, redirect the customer to the checkout confirmation page when returning back to store (otherwise process the order). Add a notice to the checkout confirmation page to confirm the order.
