### PR TITLE
Tep_not_null is_object update

### DIFF
--- a/catalog/includes/functions/general.php
+++ b/catalog/includes/functions/general.php
@@ -1161,6 +1161,14 @@
       } else {
         return false;
       }
+    } elseif(is_object($value)) {
+      
+      if (is_null($value)) {
+        return false;
+      } else {
+        return true;
+      } 
+     
     } else {
       if (($value != '') && (strtolower($value) != 'null') && (strlen(trim($value)) > 0)) {
         return true;


### PR DESCRIPTION
Changed tep_not_null so to chcek if value is object because it returned warnings such as:

Warning: strtolower() expects parameter 1 to be string, object given in
and
Warning: trim() expects parameter 1 to be string, object given in
