### PR TITLE
tep_not_null update using get_object_vars

### DIFF
--- a/catalog/includes/functions/general.php
+++ b/catalog/includes/functions/general.php
@@ -1156,7 +1156,7 @@
         return false;
       }
     } elseif(is_object($value)) {
-      if (is_null($value)) {
+      if (count(get_object_vars($value)) === 0) {
         return false;
       } else {
         return true;


### PR DESCRIPTION
When $value is an object then we have to check if it has object vars because according to PHP manual "Objects with no properties are no longer considered empty."  http://us1.php.net/manual/en/function.empty.php

So is_null($value) when $value is an object it always return false. So the appropriate way to check is using get_object_vars which will return newProp, but the protected and private members will not be returned.
