### PR TITLE
added isset($SID) to tep_href_link

### DIFF
--- a/catalog/admin/includes/functions/html_output.php
+++ b/catalog/admin/includes/functions/html_output.php
@@ -45,7 +45,7 @@
 
 // Add the session ID when moving from different HTTP and HTTPS servers, or when SID is defined
     if ( ($add_session_id == true) && (SESSION_FORCE_COOKIE_USE == 'False') ) {
-      if (tep_not_null($SID)) {
+      if (isset($SID) && tep_not_null($SID)) {
         $_sid = $SID;
       } elseif ( ( ($request_type == 'NONSSL') && ($connection == 'SSL') && (ENABLE_SSL == true) ) || ( ($request_type == 'SSL') && ($connection == 'NONSSL') ) ) {
         if (HTTP_COOKIE_DOMAIN != HTTPS_COOKIE_DOMAIN) {


### PR DESCRIPTION
added isset($SID) to tep_href_link so not to provide: Notice: Undefined variable: SID in...

I know notices are not shown is osCommerce because of :

error_reporting(E_ALL & ~E_NOTICE);

but that does not mean that we don't have to check for those.
