### PR TITLE
Fix bug if $cPath == 0

### DIFF
--- a/catalog/includes/modules/boxes/bm_categories.php
+++ b/catalog/includes/modules/boxes/bm_categories.php
@@ -103,7 +103,7 @@
         }
       }
 
-      if (tep_not_null($cPath)) {
+      if (tep_not_null($cPath) && ($cPath > 0)) {
         $new_path = '';
         foreach($cPath_array as $key => $value) {
           unset($parent_id);


### PR DESCRIPTION
If  $cPath == 0 in url like this: http://localhost/oscom/product_info.php?cPath=0&products_id=15 bm_categories gives an error
