### PR TITLE
If display_cart == true redirect to the shopping cart page for both "buy...

### DIFF
--- a/catalog/includes/application_top.php
+++ b/catalog/includes/application_top.php
@@ -265,7 +265,7 @@
       tep_redirect(tep_href_link(FILENAME_COOKIE_USAGE));
     }
 
-     if ( DISPLAY_CART == 'true' ) {
+    if ( DISPLAY_CART == 'true' ) {
       $goto =  FILENAME_SHOPPING_CART;
       $parameters = array('action', 'cPath', 'products_id', 'pid');
     } else {


### PR DESCRIPTION
..._now" and "add to cart" button

if not, the page will be redirected to the product page for both buttons.

I think that also "buy now" button should redirect to the product cart if display_cart == 'true'  as this seems to me more intuitive for the customer.
