### PR TITLE
If language parameter is not valid...

### DIFF
--- a/catalog/includes/application_top.php
+++ b/catalog/includes/application_top.php
@@ -219,6 +219,10 @@
   if ( !isset($_SESSION['language']) || isset($_GET['language']) ) {
     include('includes/classes/language.php');
     $lng = new language();
+    
+    if (!array_key_exists($_GET['language'], $lng->catalog_languages)) {
+      tep_redirect(tep_href_link(FILENAME_DEFAULT));
+    } 
 
     if ( isset($_GET['language']) && !empty($_GET['language']) ) {
       $lng->set_language($_GET['language']);


### PR DESCRIPTION
..or not included in catalog languages, redirect to default page with default language.
