### PR TITLE
Remove exclusive locks from file_put_contents() calls

### DIFF
--- a/catalog/admin/includes/modules/dashboard/d_partner_news.php
+++ b/catalog/admin/includes/modules/dashboard/d_partner_news.php
@@ -110,7 +110,7 @@
           $result = json_decode($result, true);
 
           if ( is_writable(DIR_FS_CACHE) ) {
-            file_put_contents($filename, serialize($result), LOCK_EX);
+            file_put_contents($filename, serialize($result));
           }
         }
       }

--- a/catalog/includes/OSC/OM/Cache.php
+++ b/catalog/includes/OSC/OM/Cache.php
@@ -28,7 +28,7 @@ class Cache
         }
 
         if (is_writable(OSCOM_BASE_DIR . 'work/')) {
-            return file_put_contents(OSCOM_BASE_DIR . 'work/' . $key . '.cache', serialize($data), LOCK_EX) !== false;
+            return file_put_contents(OSCOM_BASE_DIR . 'work/' . $key . '.cache', serialize($data)) !== false;
         }
 
         return false;


### PR DESCRIPTION
Exclusive locks are disabled on my hosting and I'm told that's likely true of most distributed cloud-based Linux hosting. Retrieving cached configuration fails and the store won't run.

Solution: remove exclusive lock from parameters of  file_put_contents() - two occurrences