### PR TITLE
replace tep_redirect() with OSCOM::redirect() and HTTP::redirect()

### DIFF
--- a/catalog/account.php
+++ b/catalog/account.php
@@ -10,14 +10,13 @@
   Released under the GNU General Public License
 */
 
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/account.php');

--- a/catalog/account.php
+++ b/catalog/account.php
@@ -10,13 +10,14 @@
   Released under the GNU General Public License
 */
 
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/account.php');

--- a/catalog/account_edit.php
+++ b/catalog/account_edit.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -109,7 +108,7 @@
 
       $messageStack->add_session('account', SUCCESS_ACCOUNT_UPDATED, 'success');
 
-      HTTP::redirect(OSCOM::link('account.php', '', 'SSL'));
+      OSCOM::redirect('account.php', '', 'SSL');
     }
   }
 

--- a/catalog/account_edit.php
+++ b/catalog/account_edit.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -108,7 +109,7 @@
 
       $messageStack->add_session('account', SUCCESS_ACCOUNT_UPDATED, 'success');
 
-      tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('account.php', '', 'SSL'));
     }
   }
 

--- a/catalog/account_history.php
+++ b/catalog/account_history.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/account_history.php');

--- a/catalog/account_history.php
+++ b/catalog/account_history.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/account_history.php');

--- a/catalog/account_history_info.php
+++ b/catalog/account_history_info.php
@@ -11,18 +11,17 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   if (!isset($_GET['order_id']) || !is_numeric($_GET['order_id'])) {
-    HTTP::redirect(OSCOM::link('account_history.php', '', 'SSL'));
+    OSCOM::redirect('account_history.php', '', 'SSL');
   }
 
   $Qcheck = $OSCOM_Db->prepare('select o.customers_id from :table_orders o, :table_orders_status s where o.orders_id = :orders_id and o.orders_status = s.orders_status_id and s.language_id = :language_id and s.public_flag = "1"');
@@ -31,7 +30,7 @@
   $Qcheck->execute();
 
   if (($Qcheck->fetch() === false) || ($Qcheck->valueInt('customers_id') != $_SESSION['customer_id'])) {
-    HTTP::redirect(OSCOM::link('account_history.php', '', 'SSL'));
+    OSCOM::redirect('account_history.php', '', 'SSL');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/account_history_info.php');

--- a/catalog/account_history_info.php
+++ b/catalog/account_history_info.php
@@ -11,17 +11,18 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
   if (!isset($_GET['order_id']) || !is_numeric($_GET['order_id'])) {
-    tep_redirect(OSCOM::link('account_history.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('account_history.php', '', 'SSL'));
   }
 
   $Qcheck = $OSCOM_Db->prepare('select o.customers_id from :table_orders o, :table_orders_status s where o.orders_id = :orders_id and o.orders_status = s.orders_status_id and s.language_id = :language_id and s.public_flag = "1"');
@@ -30,7 +31,7 @@
   $Qcheck->execute();
 
   if (($Qcheck->fetch() === false) || ($Qcheck->valueInt('customers_id') != $_SESSION['customer_id'])) {
-    tep_redirect(OSCOM::link('account_history.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('account_history.php', '', 'SSL'));
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/account_history_info.php');

--- a/catalog/account_newsletters.php
+++ b/catalog/account_newsletters.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -39,7 +38,7 @@
 
     $messageStack->add_session('account', SUCCESS_NEWSLETTER_UPDATED, 'success');
 
-    HTTP::redirect(OSCOM::link('account.php', '', 'SSL'));
+    OSCOM::redirect('account.php', '', 'SSL');
   }
 
   $breadcrumb->add(NAVBAR_TITLE_1, OSCOM::link('account.php', '', 'SSL'));

--- a/catalog/account_newsletters.php
+++ b/catalog/account_newsletters.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -38,7 +39,7 @@
 
     $messageStack->add_session('account', SUCCESS_NEWSLETTER_UPDATED, 'success');
 
-    tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('account.php', '', 'SSL'));
   }
 
   $breadcrumb->add(NAVBAR_TITLE_1, OSCOM::link('account.php', '', 'SSL'));

--- a/catalog/account_notifications.php
+++ b/catalog/account_notifications.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -85,7 +86,7 @@
 
     $messageStack->add_session('account', SUCCESS_NOTIFICATIONS_UPDATED, 'success');
 
-    tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('account.php', '', 'SSL'));
   }
 
   $breadcrumb->add(NAVBAR_TITLE_1, OSCOM::link('account.php', '', 'SSL'));

--- a/catalog/account_notifications.php
+++ b/catalog/account_notifications.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -86,7 +85,7 @@
 
     $messageStack->add_session('account', SUCCESS_NOTIFICATIONS_UPDATED, 'success');
 
-    HTTP::redirect(OSCOM::link('account.php', '', 'SSL'));
+    OSCOM::redirect('account.php', '', 'SSL');
   }
 
   $breadcrumb->add(NAVBAR_TITLE_1, OSCOM::link('account.php', '', 'SSL'));

--- a/catalog/account_password.php
+++ b/catalog/account_password.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -51,7 +52,7 @@
 
         $messageStack->add_session('account', SUCCESS_PASSWORD_UPDATED, 'success');
 
-        tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+        HTTP::redirect(OSCOM::link('account.php', '', 'SSL'));
       } else {
         $error = true;
 

--- a/catalog/account_password.php
+++ b/catalog/account_password.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -52,7 +51,7 @@
 
         $messageStack->add_session('account', SUCCESS_PASSWORD_UPDATED, 'success');
 
-        HTTP::redirect(OSCOM::link('account.php', '', 'SSL'));
+        OSCOM::redirect('account.php', '', 'SSL');
       } else {
         $error = true;
 

--- a/catalog/address_book.php
+++ b/catalog/address_book.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/address_book.php');

--- a/catalog/address_book.php
+++ b/catalog/address_book.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/address_book.php');

--- a/catalog/address_book_process.php
+++ b/catalog/address_book_process.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -33,7 +32,7 @@
       $messageStack->add_session('addressbook', SUCCESS_ADDRESS_BOOK_ENTRY_DELETED, 'success');
     }
 
-    HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
+    OSCOM::redirect('address_book.php', '', 'SSL');
   }
 
 // error checking when updating or adding an entry
@@ -212,7 +211,7 @@
         }
       }
 
-      HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
+      OSCOM::redirect('address_book.php', '', 'SSL');
     }
   }
 
@@ -225,7 +224,7 @@
     if ($Qentry->fetch() === false) {
       $messageStack->add_session('addressbook', ERROR_NONEXISTING_ADDRESS_BOOK_ENTRY);
 
-      HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
+      OSCOM::redirect('address_book.php', '', 'SSL');
     }
 
     $entry = $Qentry->toArray();
@@ -233,7 +232,7 @@
     if ($_GET['delete'] == $_SESSION['customer_default_address_id']) {
       $messageStack->add_session('addressbook', WARNING_PRIMARY_ADDRESS_DELETION, 'warning');
 
-      HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
+      OSCOM::redirect('address_book.php', '', 'SSL');
     } else {
       $Qcheck = $OSCOM_Db->prepare('select address_book_id from :table_address_book where address_book_id = :address_book_id and customers_id = :customers_id');
       $Qcheck->bindInt(':address_book_id', $_GET['delete']);
@@ -243,7 +242,7 @@
       if ($Qcheck->fetch() === false) {
         $messageStack->add_session('addressbook', ERROR_NONEXISTING_ADDRESS_BOOK_ENTRY);
 
-        HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
+        OSCOM::redirect('address_book.php', '', 'SSL');
       }
     }
   } else {
@@ -254,7 +253,7 @@
     if (tep_count_customer_address_book_entries() >= MAX_ADDRESS_BOOK_ENTRIES) {
       $messageStack->add_session('addressbook', ERROR_ADDRESS_BOOK_FULL);
 
-      HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
+      OSCOM::redirect('address_book.php', '', 'SSL');
     }
   }
 

--- a/catalog/address_book_process.php
+++ b/catalog/address_book_process.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -32,7 +33,7 @@
       $messageStack->add_session('addressbook', SUCCESS_ADDRESS_BOOK_ENTRY_DELETED, 'success');
     }
 
-    tep_redirect(OSCOM::link('address_book.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
   }
 
 // error checking when updating or adding an entry
@@ -211,7 +212,7 @@
         }
       }
 
-      tep_redirect(OSCOM::link('address_book.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
     }
   }
 
@@ -224,7 +225,7 @@
     if ($Qentry->fetch() === false) {
       $messageStack->add_session('addressbook', ERROR_NONEXISTING_ADDRESS_BOOK_ENTRY);
 
-      tep_redirect(OSCOM::link('address_book.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
     }
 
     $entry = $Qentry->toArray();
@@ -232,7 +233,7 @@
     if ($_GET['delete'] == $_SESSION['customer_default_address_id']) {
       $messageStack->add_session('addressbook', WARNING_PRIMARY_ADDRESS_DELETION, 'warning');
 
-      tep_redirect(OSCOM::link('address_book.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
     } else {
       $Qcheck = $OSCOM_Db->prepare('select address_book_id from :table_address_book where address_book_id = :address_book_id and customers_id = :customers_id');
       $Qcheck->bindInt(':address_book_id', $_GET['delete']);
@@ -242,7 +243,7 @@
       if ($Qcheck->fetch() === false) {
         $messageStack->add_session('addressbook', ERROR_NONEXISTING_ADDRESS_BOOK_ENTRY);
 
-        tep_redirect(OSCOM::link('address_book.php', '', 'SSL'));
+        HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
       }
     }
   } else {
@@ -253,7 +254,7 @@
     if (tep_count_customer_address_book_entries() >= MAX_ADDRESS_BOOK_ENTRIES) {
       $messageStack->add_session('addressbook', ERROR_ADDRESS_BOOK_FULL);
 
-      tep_redirect(OSCOM::link('address_book.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('address_book.php', '', 'SSL'));
     }
   }
 

--- a/catalog/advanced_search_result.php
+++ b/catalog/advanced_search_result.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -126,7 +127,7 @@
   }
 
   if ($error == true) {
-    tep_redirect(OSCOM::link('advanced_search.php', tep_get_all_get_params(), 'NONSSL', true, false));
+    HTTP::redirect(OSCOM::link('advanced_search.php', tep_get_all_get_params(), 'NONSSL', true, false));
   }
 
   $breadcrumb->add(NAVBAR_TITLE_1, OSCOM::link('advanced_search.php'));

--- a/catalog/advanced_search_result.php
+++ b/catalog/advanced_search_result.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -127,7 +126,7 @@
   }
 
   if ($error == true) {
-    HTTP::redirect(OSCOM::link('advanced_search.php', tep_get_all_get_params(), 'NONSSL', true, false));
+    OSCOM::redirect('advanced_search.php', tep_get_all_get_params(), 'NONSSL', true, false);
   }
 
   $breadcrumb->add(NAVBAR_TITLE_1, OSCOM::link('advanced_search.php'));

--- a/catalog/checkout_confirmation.php
+++ b/catalog/checkout_confirmation.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -19,24 +18,24 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => 'checkout_payment.php'));
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    HTTP::redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
 // avoid hack attempts during the checkout procedure by checking the internal cartID
   if (isset($_SESSION['cart']->cartID) && isset($_SESSION['cartID'])) {
     if ($_SESSION['cart']->cartID != $_SESSION['cartID']) {
-      HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      OSCOM::redirect('checkout_shipping.php', '', 'SSL');
     }
   }
 
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!isset($_SESSION['shipping'])) {
-    HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+    OSCOM::redirect('checkout_shipping.php', '', 'SSL');
   }
 
   if (isset($_POST['payment'])) $_SESSION['payment'] = $_POST['payment'];
@@ -55,7 +54,7 @@
   $payment_modules->update_status();
 
   if ( ($payment_modules->selected_module != $_SESSION['payment']) || ( is_array($payment_modules->modules) && (sizeof($payment_modules->modules) > 1) && !is_object($$_SESSION['payment']) ) || (is_object($$_SESSION['payment']) && ($$_SESSION['payment']->enabled == false)) ) {
-    HTTP::redirect(OSCOM::link('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL'));
+    OSCOM::redirect('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL');
   }
 
   if (is_array($payment_modules->modules)) {
@@ -80,7 +79,7 @@
     }
     // Out of Stock
     if ( (STOCK_ALLOW_CHECKOUT != 'true') && ($any_out_of_stock == true) ) {
-      HTTP::redirect(OSCOM::link('shopping_cart.php'));
+      OSCOM::redirect('shopping_cart.php');
     }
   }
 

--- a/catalog/checkout_confirmation.php
+++ b/catalog/checkout_confirmation.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -18,24 +19,24 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => 'checkout_payment.php'));
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    HTTP::redirect(OSCOM::link('shopping_cart.php'));
   }
 
 // avoid hack attempts during the checkout procedure by checking the internal cartID
   if (isset($_SESSION['cart']->cartID) && isset($_SESSION['cartID'])) {
     if ($_SESSION['cart']->cartID != $_SESSION['cartID']) {
-      tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
     }
   }
 
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!isset($_SESSION['shipping'])) {
-    tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
   }
 
   if (isset($_POST['payment'])) $_SESSION['payment'] = $_POST['payment'];
@@ -54,7 +55,7 @@
   $payment_modules->update_status();
 
   if ( ($payment_modules->selected_module != $_SESSION['payment']) || ( is_array($payment_modules->modules) && (sizeof($payment_modules->modules) > 1) && !is_object($$_SESSION['payment']) ) || (is_object($$_SESSION['payment']) && ($$_SESSION['payment']->enabled == false)) ) {
-    tep_redirect(OSCOM::link('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL'));
   }
 
   if (is_array($payment_modules->modules)) {
@@ -79,7 +80,7 @@
     }
     // Out of Stock
     if ( (STOCK_ALLOW_CHECKOUT != 'true') && ($any_out_of_stock == true) ) {
-      tep_redirect(OSCOM::link('shopping_cart.php'));
+      HTTP::redirect(OSCOM::link('shopping_cart.php'));
     }
   }
 

--- a/catalog/checkout_payment.php
+++ b/catalog/checkout_payment.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -18,23 +19,23 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    HTTP::redirect(OSCOM::link('shopping_cart.php'));
   }
 
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!isset($_SESSION['shipping'])) {
-    tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
   }
 
 // avoid hack attempts during the checkout procedure by checking the internal cartID
   if (isset($_SESSION['cart']->cartID) && isset($_SESSION['cartID'])) {
     if ($_SESSION['cart']->cartID != $_SESSION['cartID']) {
-      tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
     }
   }
 
@@ -43,7 +44,7 @@
     $products = $_SESSION['cart']->get_products();
     for ($i=0, $n=sizeof($products); $i<$n; $i++) {
       if (tep_check_stock($products[$i]['id'], $products[$i]['quantity'])) {
-        tep_redirect(OSCOM::link('shopping_cart.php'));
+        HTTP::redirect(OSCOM::link('shopping_cart.php'));
         break;
       }
     }

--- a/catalog/checkout_payment.php
+++ b/catalog/checkout_payment.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -19,23 +18,23 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    HTTP::redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!isset($_SESSION['shipping'])) {
-    HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+    OSCOM::redirect('checkout_shipping.php', '', 'SSL');
   }
 
 // avoid hack attempts during the checkout procedure by checking the internal cartID
   if (isset($_SESSION['cart']->cartID) && isset($_SESSION['cartID'])) {
     if ($_SESSION['cart']->cartID != $_SESSION['cartID']) {
-      HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      OSCOM::redirect('checkout_shipping.php', '', 'SSL');
     }
   }
 
@@ -44,7 +43,7 @@
     $products = $_SESSION['cart']->get_products();
     for ($i=0, $n=sizeof($products); $i<$n; $i++) {
       if (tep_check_stock($products[$i]['id'], $products[$i]['quantity'])) {
-        HTTP::redirect(OSCOM::link('shopping_cart.php'));
+        OSCOM::redirect('shopping_cart.php');
         break;
       }
     }

--- a/catalog/checkout_payment_address.php
+++ b/catalog/checkout_payment_address.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -19,12 +18,12 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    HTTP::redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -159,7 +158,7 @@
 
         if (isset($_SESSION['payment'])) unset($_SESSION['payment']);
 
-        HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+        OSCOM::redirect('checkout_payment.php', '', 'SSL');
       }
 // process the selected billing destination
     } elseif (isset($_POST['address'])) {
@@ -181,7 +180,7 @@
 
       if ($Qcheck->fetch() !== false) {
         if ($reset_payment == true) unset($_SESSION['payment']);
-        HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+        OSCOM::redirect('checkout_payment.php', '', 'SSL');
       } else {
         unset($_SESSION['billto']);
       }
@@ -189,7 +188,7 @@
     } else {
       $_SESSION['billto'] = $_SESSION['customer_default_address_id'];
 
-      HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+      OSCOM::redirect('checkout_payment.php', '', 'SSL');
     }
   }
 

--- a/catalog/checkout_payment_address.php
+++ b/catalog/checkout_payment_address.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -18,12 +19,12 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    HTTP::redirect(OSCOM::link('shopping_cart.php'));
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -158,7 +159,7 @@
 
         if (isset($_SESSION['payment'])) unset($_SESSION['payment']);
 
-        tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+        HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
       }
 // process the selected billing destination
     } elseif (isset($_POST['address'])) {
@@ -180,7 +181,7 @@
 
       if ($Qcheck->fetch() !== false) {
         if ($reset_payment == true) unset($_SESSION['payment']);
-        tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+        HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
       } else {
         unset($_SESSION['billto']);
       }
@@ -188,7 +189,7 @@
     } else {
       $_SESSION['billto'] = $_SESSION['customer_default_address_id'];
 
-      tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
     }
   }
 

--- a/catalog/checkout_process.php
+++ b/catalog/checkout_process.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   include('includes/application_top.php');
@@ -18,27 +19,27 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => 'checkout_payment.php'));
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    HTTP::redirect(OSCOM::link('shopping_cart.php'));
   }
 
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!isset($_SESSION['shipping']) || !isset($_SESSION['sendto'])) {
-    tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
   }
 
   if ( (tep_not_null(MODULE_PAYMENT_INSTALLED)) && (!isset($_SESSION['payment'])) ) {
-    tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
  }
 
 // avoid hack attempts during the checkout procedure by checking the internal cartID
   if (isset($_SESSION['cart']->cartID) && isset($_SESSION['cartID'])) {
     if ($_SESSION['cart']->cartID != $_SESSION['cartID']) {
-      tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
     }
   }
 
@@ -65,14 +66,14 @@
     }
     // Out of Stock
     if ( (STOCK_ALLOW_CHECKOUT != 'true') && ($any_out_of_stock == true) ) {
-      tep_redirect(OSCOM::link('shopping_cart.php'));
+      HTTP::redirect(OSCOM::link('shopping_cart.php'));
     }
   }
 
   $payment_modules->update_status();
 
   if ( ($payment_modules->selected_module != $_SESSION['payment']) || ( is_array($payment_modules->modules) && (sizeof($payment_modules->modules) > 1) && !is_object($$_SESSION['payment']) ) || (is_object($$_SESSION['payment']) && ($$_SESSION['payment']->enabled == false)) ) {
-    tep_redirect(OSCOM::link('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL'));
   }
 
   require(DIR_WS_CLASSES . 'order_total.php');
@@ -335,7 +336,7 @@
   unset($_SESSION['payment']);
   unset($_SESSION['comments']);
 
-  tep_redirect(OSCOM::link('checkout_success.php', '', 'SSL'));
+  HTTP::redirect(OSCOM::link('checkout_success.php', '', 'SSL'));
 
   require('includes/application_bottom.php');
 ?>

--- a/catalog/checkout_process.php
+++ b/catalog/checkout_process.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   include('includes/application_top.php');
@@ -19,27 +18,27 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => 'checkout_payment.php'));
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    HTTP::redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!isset($_SESSION['shipping']) || !isset($_SESSION['sendto'])) {
-    HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+    OSCOM::redirect('checkout_shipping.php', '', 'SSL');
   }
 
   if ( (tep_not_null(MODULE_PAYMENT_INSTALLED)) && (!isset($_SESSION['payment'])) ) {
-    HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    OSCOM::redirect('checkout_payment.php', '', 'SSL');
  }
 
 // avoid hack attempts during the checkout procedure by checking the internal cartID
   if (isset($_SESSION['cart']->cartID) && isset($_SESSION['cartID'])) {
     if ($_SESSION['cart']->cartID != $_SESSION['cartID']) {
-      HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      OSCOM::redirect('checkout_shipping.php', '', 'SSL');
     }
   }
 
@@ -66,14 +65,14 @@
     }
     // Out of Stock
     if ( (STOCK_ALLOW_CHECKOUT != 'true') && ($any_out_of_stock == true) ) {
-      HTTP::redirect(OSCOM::link('shopping_cart.php'));
+      OSCOM::redirect('shopping_cart.php');
     }
   }
 
   $payment_modules->update_status();
 
   if ( ($payment_modules->selected_module != $_SESSION['payment']) || ( is_array($payment_modules->modules) && (sizeof($payment_modules->modules) > 1) && !is_object($$_SESSION['payment']) ) || (is_object($$_SESSION['payment']) && ($$_SESSION['payment']->enabled == false)) ) {
-    HTTP::redirect(OSCOM::link('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL'));
+    OSCOM::redirect('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL');
   }
 
   require(DIR_WS_CLASSES . 'order_total.php');
@@ -336,7 +335,7 @@
   unset($_SESSION['payment']);
   unset($_SESSION['comments']);
 
-  HTTP::redirect(OSCOM::link('checkout_success.php', '', 'SSL'));
+  OSCOM::redirect('checkout_success.php', '', 'SSL');
 
   require('includes/application_bottom.php');
 ?>

--- a/catalog/checkout_shipping.php
+++ b/catalog/checkout_shipping.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -19,12 +20,12 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    HTTP::redirect(OSCOM::link('shopping_cart.php'));
   }
 
 // if no shipping destination address was selected, use the customers own address as default
@@ -61,7 +62,7 @@
   if ($order->content_type == 'virtual') {
     $_SESSION['shipping'] = false;
     $_SESSION['sendto'] = false;
-    tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
   }
 
   $total_weight = $_SESSION['cart']->show_weight();
@@ -126,7 +127,7 @@
                                             'title' => (($free_shipping == true) ?  $quote[0]['methods'][0]['title'] : $quote[0]['module'] . ' (' . $quote[0]['methods'][0]['title'] . ')'),
                                             'cost' => $quote[0]['methods'][0]['cost']);
 
-              tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+              HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
             }
           }
         } else {
@@ -139,7 +140,7 @@
       } else {
         $_SESSION['shipping'] = false;
 
-        tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+        HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
       }
     }
   }
@@ -158,7 +159,7 @@
   if ( defined('SHIPPING_ALLOW_UNDEFINED_ZONES') && (SHIPPING_ALLOW_UNDEFINED_ZONES == 'False') && (!isset($_SESSION['shipping']) || ($_SESSION['shipping'] === false)) ) {
     $messageStack->add_session('checkout_address', ERROR_NO_SHIPPING_AVAILABLE_TO_SHIPPING_ADDRESS);
 
-    tep_redirect(OSCOM::link('checkout_shipping_address.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_shipping_address.php', '', 'SSL'));
   }
 
   $breadcrumb->add(NAVBAR_TITLE_1, OSCOM::link('checkout_shipping.php', '', 'SSL'));

--- a/catalog/checkout_shipping.php
+++ b/catalog/checkout_shipping.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -20,12 +19,12 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    HTTP::redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
 // if no shipping destination address was selected, use the customers own address as default
@@ -62,7 +61,7 @@
   if ($order->content_type == 'virtual') {
     $_SESSION['shipping'] = false;
     $_SESSION['sendto'] = false;
-    HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    OSCOM::redirect('checkout_payment.php', '', 'SSL');
   }
 
   $total_weight = $_SESSION['cart']->show_weight();
@@ -127,7 +126,7 @@
                                             'title' => (($free_shipping == true) ?  $quote[0]['methods'][0]['title'] : $quote[0]['module'] . ' (' . $quote[0]['methods'][0]['title'] . ')'),
                                             'cost' => $quote[0]['methods'][0]['cost']);
 
-              HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+              OSCOM::redirect('checkout_payment.php', '', 'SSL');
             }
           }
         } else {
@@ -140,7 +139,7 @@
       } else {
         $_SESSION['shipping'] = false;
 
-        HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+        OSCOM::redirect('checkout_payment.php', '', 'SSL');
       }
     }
   }
@@ -159,7 +158,7 @@
   if ( defined('SHIPPING_ALLOW_UNDEFINED_ZONES') && (SHIPPING_ALLOW_UNDEFINED_ZONES == 'False') && (!isset($_SESSION['shipping']) || ($_SESSION['shipping'] === false)) ) {
     $messageStack->add_session('checkout_address', ERROR_NO_SHIPPING_AVAILABLE_TO_SHIPPING_ADDRESS);
 
-    HTTP::redirect(OSCOM::link('checkout_shipping_address.php', '', 'SSL'));
+    OSCOM::redirect('checkout_shipping_address.php', '', 'SSL');
   }
 
   $breadcrumb->add(NAVBAR_TITLE_1, OSCOM::link('checkout_shipping.php', '', 'SSL'));

--- a/catalog/checkout_shipping_address.php
+++ b/catalog/checkout_shipping_address.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -19,12 +18,12 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    HTTP::redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
   // needs to be included earlier to set the success message in the messageStack
@@ -38,7 +37,7 @@
   if ($order->content_type == 'virtual') {
     $_SESSION['shipping'] = false;
     $_SESSION['sendto'] = false;
-    HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    OSCOM::redirect('checkout_payment.php', '', 'SSL');
   }
 
   $error = false;
@@ -170,7 +169,7 @@
 
         if (isset($_SESSION['shipping'])) unset($_SESSION['shipping']);
 
-        HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+        OSCOM::redirect('checkout_shipping.php', '', 'SSL');
       }
 // process the selected shipping destination
     } elseif (isset($_POST['address'])) {
@@ -192,14 +191,14 @@
 
       if ($Qcheck->fetch() !== false) {
         if ($reset_shipping == true) unset($_SESSION['shipping']);
-        HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+        OSCOM::redirect('checkout_shipping.php', '', 'SSL');
       } else {
         unset($_SESSION['sendto']);
       }
     } else {
       $_SESSION['sendto'] = $_SESSION['customer_default_address_id'];
 
-      HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      OSCOM::redirect('checkout_shipping.php', '', 'SSL');
     }
   }
 

--- a/catalog/checkout_shipping_address.php
+++ b/catalog/checkout_shipping_address.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -18,12 +19,12 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    HTTP::redirect(OSCOM::link('shopping_cart.php'));
   }
 
   // needs to be included earlier to set the success message in the messageStack
@@ -37,7 +38,7 @@
   if ($order->content_type == 'virtual') {
     $_SESSION['shipping'] = false;
     $_SESSION['sendto'] = false;
-    tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
   }
 
   $error = false;
@@ -169,7 +170,7 @@
 
         if (isset($_SESSION['shipping'])) unset($_SESSION['shipping']);
 
-        tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+        HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
       }
 // process the selected shipping destination
     } elseif (isset($_POST['address'])) {
@@ -191,14 +192,14 @@
 
       if ($Qcheck->fetch() !== false) {
         if ($reset_shipping == true) unset($_SESSION['shipping']);
-        tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+        HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
       } else {
         unset($_SESSION['sendto']);
       }
     } else {
       $_SESSION['sendto'] = $_SESSION['customer_default_address_id'];
 
-      tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
     }
   }
 

--- a/catalog/checkout_success.php
+++ b/catalog/checkout_success.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
 // if the customer is not logged on, redirect them to the shopping cart page
   if (!isset($_SESSION['customer_id'])) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    HTTP::redirect(OSCOM::link('shopping_cart.php'));
   }
 
   $Qorders = $OSCOM_Db->prepare('select orders_id from :table_orders where customers_id = :customers_id order by date_purchased desc limit 1');
@@ -26,7 +27,7 @@
 
 // redirect to shopping cart page if no orders exist
   if ($Qorders->fetch() === false) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    HTTP::redirect(OSCOM::link('shopping_cart.php'));
   }
 
   $orders = $Qorders->toArray(); // TODO replace $orders used in template content modules with $Qorders
@@ -36,7 +37,7 @@
   $page_content = $oscTemplate->getContent('checkout_success');
 
   if ( isset($_GET['action']) && ($_GET['action'] == 'update') ) {
-    tep_redirect(OSCOM::link('index.php'));
+    HTTP::redirect(OSCOM::link('index.php'));
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/checkout_success.php');

--- a/catalog/checkout_success.php
+++ b/catalog/checkout_success.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
 // if the customer is not logged on, redirect them to the shopping cart page
   if (!isset($_SESSION['customer_id'])) {
-    HTTP::redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
   $Qorders = $OSCOM_Db->prepare('select orders_id from :table_orders where customers_id = :customers_id order by date_purchased desc limit 1');
@@ -27,7 +26,7 @@
 
 // redirect to shopping cart page if no orders exist
   if ($Qorders->fetch() === false) {
-    HTTP::redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
   $orders = $Qorders->toArray(); // TODO replace $orders used in template content modules with $Qorders
@@ -37,7 +36,7 @@
   $page_content = $oscTemplate->getContent('checkout_success');
 
   if ( isset($_GET['action']) && ($_GET['action'] == 'update') ) {
-    HTTP::redirect(OSCOM::link('index.php'));
+    OSCOM::redirect('index.php');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/checkout_success.php');

--- a/catalog/contact_us.php
+++ b/catalog/contact_us.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -44,7 +45,7 @@
 
       $actionRecorder->record();
 
-      tep_redirect(OSCOM::link('contact_us.php', 'action=success'));
+      HTTP::redirect(OSCOM::link('contact_us.php', 'action=success'));
     }
   }
 

--- a/catalog/contact_us.php
+++ b/catalog/contact_us.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -45,7 +44,7 @@
 
       $actionRecorder->record();
 
-      HTTP::redirect(OSCOM::link('contact_us.php', 'action=success'));
+      OSCOM::redirect('contact_us.php', 'action=success');
     }
   }
 

--- a/catalog/create_account.php
+++ b/catalog/create_account.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -253,7 +252,7 @@
       $email_text .= EMAIL_WELCOME . EMAIL_TEXT . EMAIL_CONTACT . EMAIL_WARNING;
       tep_mail($name, $email_address, EMAIL_SUBJECT, $email_text, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
 
-      HTTP::redirect(OSCOM::link('create_account_success.php', '', 'SSL'));
+      OSCOM::redirect('create_account_success.php', '', 'SSL');
     }
   }
 

--- a/catalog/create_account.php
+++ b/catalog/create_account.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -252,7 +253,7 @@
       $email_text .= EMAIL_WELCOME . EMAIL_TEXT . EMAIL_CONTACT . EMAIL_WARNING;
       tep_mail($name, $email_address, EMAIL_SUBJECT, $email_text, STORE_OWNER, STORE_OWNER_EMAIL_ADDRESS);
 
-      tep_redirect(OSCOM::link('create_account_success.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('create_account_success.php', '', 'SSL'));
     }
   }
 

--- a/catalog/download.php
+++ b/catalog/download.php
@@ -10,7 +10,6 @@
   Released under the GNU General Public License
 */
 
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   include('includes/application_top.php');
@@ -102,7 +101,7 @@ function tep_unlink_temp_dir($dir)
     mkdir(DIR_FS_DOWNLOAD_PUBLIC . $tempdir, 0777);
     symlink(DIR_FS_DOWNLOAD . $Qdownload->value('orders_products_filename'), DIR_FS_DOWNLOAD_PUBLIC . $tempdir . '/' . $Qdownload->value('orders_products_filename'));
     if (file_exists(DIR_FS_DOWNLOAD_PUBLIC . $tempdir . '/' . $Qdownload->value('orders_products_filename'))) {
-      HTTP::redirect(OSCOM::link(DIR_WS_DOWNLOAD_PUBLIC . $tempdir . '/' . $Qdownload->value('orders_products_filename')));
+      OSCOM::redirect(DIR_WS_DOWNLOAD_PUBLIC . $tempdir . '/' . $Qdownload->value('orders_products_filename'));
     }
   }
 

--- a/catalog/download.php
+++ b/catalog/download.php
@@ -10,6 +10,7 @@
   Released under the GNU General Public License
 */
 
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   include('includes/application_top.php');
@@ -101,7 +102,7 @@ function tep_unlink_temp_dir($dir)
     mkdir(DIR_FS_DOWNLOAD_PUBLIC . $tempdir, 0777);
     symlink(DIR_FS_DOWNLOAD . $Qdownload->value('orders_products_filename'), DIR_FS_DOWNLOAD_PUBLIC . $tempdir . '/' . $Qdownload->value('orders_products_filename'));
     if (file_exists(DIR_FS_DOWNLOAD_PUBLIC . $tempdir . '/' . $Qdownload->value('orders_products_filename'))) {
-      tep_redirect(OSCOM::link(DIR_WS_DOWNLOAD_PUBLIC . $tempdir . '/' . $Qdownload->value('orders_products_filename')));
+      HTTP::redirect(OSCOM::link(DIR_WS_DOWNLOAD_PUBLIC . $tempdir . '/' . $Qdownload->value('orders_products_filename')));
     }
   }
 

--- a/catalog/ext/modules/content/account/braintree/cards.php
+++ b/catalog/ext/modules/content/account/braintree/cards.php
@@ -18,7 +18,7 @@
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   if ( defined('MODULE_PAYMENT_INSTALLED') && tep_not_null(MODULE_PAYMENT_INSTALLED) && in_array('braintree_cc.php', explode(';', MODULE_PAYMENT_INSTALLED)) ) {
@@ -30,10 +30,10 @@
     $braintree_cc = new braintree_cc();
 
     if ( !$braintree_cc->enabled ) {
-      tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+      OSCOM::redirect('account.php', '', 'SSL');
     }
   } else {
-    tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+    OSCOM::redirect('account.php', '', 'SSL');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/content/account/cm_account_braintree_cards.php');
@@ -41,7 +41,7 @@
   $braintree_cards = new cm_account_braintree_cards();
 
   if ( !$braintree_cards->isEnabled() ) {
-    tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+    OSCOM::redirect('account.php', '', 'SSL');
   }
 
   if ( isset($_GET['action']) ) {
@@ -55,7 +55,7 @@
       }
     }
 
-    tep_redirect(OSCOM::link('ext/modules/content/account/braintree/cards.php', '', 'SSL'));
+    OSCOM::redirect('ext/modules/content/account/braintree/cards.php', '', 'SSL');
   }
 
   $breadcrumb->add(MODULE_CONTENT_ACCOUNT_BRAINTREE_CARDS_NAVBAR_TITLE_1, OSCOM::link('account.php', '', 'SSL'));

--- a/catalog/ext/modules/content/account/sage_pay/cards.php
+++ b/catalog/ext/modules/content/account/sage_pay/cards.php
@@ -18,7 +18,7 @@
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   if ( defined('MODULE_PAYMENT_INSTALLED') && tep_not_null(MODULE_PAYMENT_INSTALLED) && in_array('sage_pay_direct.php', explode(';', MODULE_PAYMENT_INSTALLED)) ) {
@@ -30,10 +30,10 @@
     $sage_pay_direct = new sage_pay_direct();
 
     if ( !$sage_pay_direct->enabled ) {
-      tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+      OSCOM::redirect('account.php', '', 'SSL');
     }
   } else {
-    tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+    OSCOM::redirect('account.php', '', 'SSL');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/modules/content/account/cm_account_sage_pay_cards.php');
@@ -41,7 +41,7 @@
   $sage_pay_cards = new cm_account_sage_pay_cards();
 
   if ( !$sage_pay_cards->isEnabled() ) {
-    tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+    OSCOM::redirect('account.php', '', 'SSL');
   }
 
   if ( isset($_GET['action']) ) {
@@ -55,7 +55,7 @@
       }
     }
 
-    tep_redirect(OSCOM::link('ext/modules/content/account/sage_pay/cards.php', '', 'SSL'));
+    OSCOM::redirect('ext/modules/content/account/sage_pay/cards.php', '', 'SSL');
   }
 
   $breadcrumb->add(MODULE_CONTENT_ACCOUNT_SAGE_PAY_CARDS_NAVBAR_TITLE_1, OSCOM::link('account.php', '', 'SSL'));

--- a/catalog/ext/modules/content/account/set_password.php
+++ b/catalog/ext/modules/content/account/set_password.php
@@ -17,17 +17,17 @@
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id'])) {
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   if ( MODULE_CONTENT_ACCOUNT_SET_PASSWORD_ALLOW_PASSWORD != 'True' ) {
-    tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+    OSCOM::redirect('account.php', '', 'SSL');
   }
 
   $Qcustomer = $OSCOM_Db-get('customers', 'customers_password', ['customers_id' => $_SESSION['customer_id']]);
 
   if (!empty($Qcustomer->value('customers_password'))) {
-    tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+    OSCOM::redirect('account.php', '', 'SSL');
   }
 
 // needs to be included earlier to set the success message in the messageStack
@@ -55,7 +55,7 @@
 
       $messageStack->add_session('account', MODULE_CONTENT_ACCOUNT_SET_PASSWORD_SUCCESS_PASSWORD_SET, 'success');
 
-      tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+      OSCOM::redirect('account.php', '', 'SSL');
     }
   }
 

--- a/catalog/ext/modules/payment/sage_pay/checkout.php
+++ b/catalog/ext/modules/payment/sage_pay/checkout.php
@@ -10,6 +10,7 @@
   Released under the GNU General Public License
 */
 
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   chdir('../../../../');
@@ -18,28 +19,28 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => 'checkout_payment.php'));
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
 // if there is nothing in the customers cart, redirect them to the shopping cart page
   if ($_SESSION['cart']->count_contents() < 1) {
-    tep_redirect(OSCOM::link('shopping_cart.php'));
+    OSCOM::redirect('shopping_cart.php');
   }
 
 // avoid hack attempts during the checkout procedure by checking the internal cartID
   if (isset($_SESSION['cart']->cartID) && isset($_SESSION['cartID'])) {
     if ($_SESSION['cart']->cartID != $_SESSION['cartID']) {
-      tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+      OSCOM::redirect('checkout_shipping.php', '', 'SSL');
     }
   }
 
 // if no shipping method has been selected, redirect the customer to the shipping method selection page
   if (!isset($_SESSION['shipping'])) {
-    tep_redirect(OSCOM::link('checkout_shipping.php', '', 'SSL'));
+    OSCOM::redirect('checkout_shipping.php', '', 'SSL');
   }
 
   if (!isset($_SESSION['payment']) || (($_SESSION['payment'] != 'sage_pay_direct') && ($_SESSION['payment'] != 'sage_pay_server')) || (($_SESSION['payment'] == 'sage_pay_server') && !isset($_SESSION['sage_pay_server_nexturl']))) {
-    tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    OSCOM::redirect('checkout_payment.php', '', 'SSL');
   }
 
 // load the selected payment module
@@ -52,7 +53,7 @@
   $payment_modules->update_status();
 
   if ( ( is_array($payment_modules->modules) && (sizeof($payment_modules->modules) > 1) && !is_object($$_SESSION['payment']) ) || (is_object($$_SESSION['payment']) && ($$_SESSION['payment']->enabled == false)) ) {
-    tep_redirect(OSCOM::link('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL'));
+    OSCOM::redirect('checkout_payment.php', 'error_message=' . urlencode(ERROR_NO_PAYMENT_MODULE_SELECTED), 'SSL');
   }
 
   if (is_array($payment_modules->modules)) {
@@ -77,7 +78,7 @@
     }
     // Out of Stock
     if ( (STOCK_ALLOW_CHECKOUT != 'true') && ($any_out_of_stock == true) ) {
-      tep_redirect(OSCOM::link('shopping_cart.php'));
+      OSCOM::redirect('shopping_cart.php');
     }
   }
 
@@ -93,7 +94,7 @@
   }
 
   if ( !file_exists(DIR_FS_CATALOG . 'includes/template_top.php') ) {
-    tep_redirect($iframe_url);
+    HTTP::redirect($iframe_url);
   }
 
   include('includes/template_top.php');

--- a/catalog/ext/modules/payment/sage_pay/direct_3dauth.php
+++ b/catalog/ext/modules/payment/sage_pay/direct_3dauth.php
@@ -18,15 +18,15 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => 'checkout_payment.php'));
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   if (!isset($_SESSION['sage_pay_direct_acsurl'])) {
-    tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    OSCOM::redirect('checkout_payment.php', '', 'SSL');
   }
 
   if (!isset($_SESSION['payment']) || ($_SESSION['payment'] != 'sage_pay_direct')) {
-    tep_redirect(OSCOM::link('checkout_payment.php', '', 'SSL'));
+    OSCOM::redirect('checkout_payment.php', '', 'SSL');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/checkout_confirmation.php');

--- a/catalog/ext/modules/payment/sage_pay/redirect.php
+++ b/catalog/ext/modules/payment/sage_pay/redirect.php
@@ -19,7 +19,7 @@
 // if the customer is not logged on, redirect them to the login page
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot(array('mode' => 'SSL', 'page' => 'checkout_payment.php'));
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   if ( isset($_GET['payment_error']) && tep_not_null($_GET['payment_error']) ) {

--- a/catalog/includes/OSC/OM/HTTP.php
+++ b/catalog/includes/OSC/OM/HTTP.php
@@ -8,17 +8,19 @@
 
 namespace OSC\OM;
 
+use OSC\OM\OSCOM;
+
 class HTTP
 {
     public static function redirect($url)
     {
         global $request_type;
 
-        if ( (strstr($url, "\n") != false) || (strstr($url, "\r") != false) ) {
-            tep_redirect(tep_href_link('index.php', '', 'NONSSL', false));
+        if ((strstr($url, "\n") !== false) || (strstr($url, "\r") !== false)) {
+            $url = OSCOM::link('index.php', '', 'NONSSL', false);
         }
 
-        if ( (ENABLE_SSL == true) && ($request_type == 'SSL') ) { // We are loading an SSL page
+        if ((ENABLE_SSL == true) && ($request_type == 'SSL')) { // We are loading an SSL page
             if (substr($url, 0, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)) == HTTP_SERVER . DIR_WS_HTTP_CATALOG) { // NONSSL url
                 $url = HTTPS_SERVER . DIR_WS_HTTPS_CATALOG . substr($url, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)); // Change it to SSL
             }
@@ -30,6 +32,6 @@ class HTTP
 
         header('Location: ' . $url);
 
-        tep_exit();
+        exit();
     }
 }

--- a/catalog/includes/OSC/OM/HTTP.php
+++ b/catalog/includes/OSC/OM/HTTP.php
@@ -8,30 +8,18 @@
 
 namespace OSC\OM;
 
-use OSC\OM\OSCOM;
-
 class HTTP
 {
     public static function redirect($url)
     {
-        global $request_type;
-
-        if ((strstr($url, "\n") !== false) || (strstr($url, "\r") !== false)) {
-            $url = OSCOM::link('index.php', '', 'NONSSL', false);
-        }
-
-        if ((ENABLE_SSL == true) && ($request_type == 'SSL')) { // We are loading an SSL page
-            if (substr($url, 0, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)) == HTTP_SERVER . DIR_WS_HTTP_CATALOG) { // NONSSL url
-                $url = HTTPS_SERVER . DIR_WS_HTTPS_CATALOG . substr($url, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)); // Change it to SSL
+        if ((strstr($url, "\n") === false) && (strstr($url, "\r") === false)) {
+            if ( strpos($url, '&amp;') !== false ) {
+                $url = str_replace('&amp;', '&', $url);
             }
+
+            header('Location: ' . $url);
         }
 
-        if ( strpos($url, '&amp;') !== false ) {
-            $url = str_replace('&amp;', '&', $url);
-        }
-
-        header('Location: ' . $url);
-
-        exit();
+        exit;
     }
 }

--- a/catalog/includes/OSC/OM/HTTP.php
+++ b/catalog/includes/OSC/OM/HTTP.php
@@ -1,0 +1,35 @@
+<?php
+/**
+  * osCommerce Online Merchant
+  *
+  * @copyright Copyright (c) 2015 osCommerce; http://www.oscommerce.com
+  * @license GPL; http://www.oscommerce.com/gpllicense.txt
+  */
+
+namespace OSC\OM;
+
+class HTTP
+{
+    public static function redirect($url)
+    {
+        global $request_type;
+
+        if ( (strstr($url, "\n") != false) || (strstr($url, "\r") != false) ) {
+            tep_redirect(tep_href_link('index.php', '', 'NONSSL', false));
+        }
+
+        if ( (ENABLE_SSL == true) && ($request_type == 'SSL') ) { // We are loading an SSL page
+            if (substr($url, 0, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)) == HTTP_SERVER . DIR_WS_HTTP_CATALOG) { // NONSSL url
+                $url = HTTPS_SERVER . DIR_WS_HTTPS_CATALOG . substr($url, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)); // Change it to SSL
+            }
+        }
+
+        if ( strpos($url, '&amp;') !== false ) {
+            $url = str_replace('&amp;', '&', $url);
+        }
+
+        header('Location: ' . $url);
+
+        tep_exit();
+    }
+}

--- a/catalog/includes/OSC/OM/OSCOM.php
+++ b/catalog/includes/OSC/OM/OSCOM.php
@@ -14,7 +14,7 @@ class OSCOM
 {
     public static function link($page, $parameters = null, $connection = 'NONSSL', $add_session_id = true, $search_engine_safe = true)
     {
-        global $request_type, $session_started, $SID;
+        global $request_type;
 
         $page = HTML::sanitize($page);
 
@@ -58,9 +58,9 @@ class OSCOM
         }
 
 // Add the session ID when moving from different HTTP and HTTPS servers, or when SID is defined
-        if (($add_session_id == true) && ($session_started == true) && (SESSION_FORCE_COOKIE_USE == 'False')) {
-            if (!empty($SID)) {
-                $_sid = $SID;
+        if (($add_session_id == true) && (session_status() === PHP_SESSION_ACTIVE) && (SESSION_FORCE_COOKIE_USE == 'False')) {
+            if (defined('SID') && !empty(SID)) {
+                $_sid = SID;
             } elseif ((($request_type == 'NONSSL') && ($connection == 'SSL')) || (($request_type == 'SSL') && ($connection == 'NONSSL'))) {
                 if (HTTP_COOKIE_DOMAIN != HTTPS_COOKIE_DOMAIN) {
                     $_sid = session_name() . '=' . session_id();

--- a/catalog/includes/OSC/OM/OSCOM.php
+++ b/catalog/includes/OSC/OM/OSCOM.php
@@ -9,6 +9,7 @@
 namespace OSC\OM;
 
 use OSC\OM\HTML;
+use OSC\OM\HTTP;
 
 class OSCOM
 {
@@ -81,5 +82,24 @@ class OSCOM
         }
 
         return $link;
+    }
+
+    public static function redirect()
+    {
+        global $request_type;
+
+        $url = forward_static_call_array('static::link', func_get_args());
+
+        if ((strstr($url, "\n") !== false) || (strstr($url, "\r") !== false)) {
+            $url = static::link('index.php', '', 'NONSSL', false);
+        }
+
+        if ((ENABLE_SSL == true) && ($request_type == 'SSL')) { // We are loading an SSL page
+            if (substr($url, 0, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)) == HTTP_SERVER . DIR_WS_HTTP_CATALOG) { // NONSSL url
+                $url = HTTPS_SERVER . DIR_WS_HTTPS_CATALOG . substr($url, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)); // Change it to SSL
+            }
+        }
+
+        HTTP::redirect($url);
     }
 }

--- a/catalog/includes/application_top.php
+++ b/catalog/includes/application_top.php
@@ -174,7 +174,7 @@
     if ( $_SESSION['SESSION_SSL_ID'] != $_SERVER['SSL_SESSION_ID'] ) {
       tep_session_destroy();
 
-      tep_redirect(OSCOM::link('ssl_check.php'));
+      OSCOM::redirect('ssl_check.php');
     }
   }
 
@@ -186,7 +186,7 @@
 
     if ( $_SESSION['SESSION_USER_AGENT'] != $_SERVER['HTTP_USER_AGENT'] ) {
       tep_session_destroy();
-      tep_redirect(OSCOM::link('login.php'));
+      OSCOM::redirect('login.php');
     }
   }
 
@@ -198,7 +198,7 @@
 
     if ( $_SESSION['SESSION_IP_ADDRESS'] != tep_get_ip_address() ) {
       tep_session_destroy();
-      tep_redirect(OSCOM::link('login.php'));
+      OSCOM::redirect('login.php');
     }
   }
 
@@ -262,7 +262,7 @@
   if ( isset($_GET['action']) ) {
 // redirect the customer to a friendly cookie-must-be-enabled page if cookies are disabled
     if ( $session_started == false ) {
-      tep_redirect(OSCOM::link('cookie_usage.php'));
+      OSCOM::redirect('cookie_usage.php');
     }
 
     if ( DISPLAY_CART == 'true' ) {
@@ -285,7 +285,7 @@
                                 $_SESSION['cart']->add_cart($_POST['products_id'][$i], $_POST['cart_quantity'][$i], $attributes, false);
                                 $messageStack->add_session('product_action', sprintf(PRODUCT_ADDED, tep_get_products_name((int)$_POST['products_id'][$i])), 'success');
                               }
-                              tep_redirect(OSCOM::link($goto, tep_get_all_get_params($parameters)));
+                              OSCOM::redirect($goto, tep_get_all_get_params($parameters));
                               break;
       // customer adds a product from the products page
       case 'add_product' :    if (isset($_POST['products_id']) && is_numeric($_POST['products_id'])) {
@@ -293,25 +293,25 @@
                                 $_SESSION['cart']->add_cart($_POST['products_id'], $_SESSION['cart']->get_quantity(tep_get_uprid($_POST['products_id'], $attributes))+1, $attributes);
                                 $messageStack->add_session('product_action', sprintf(PRODUCT_ADDED, tep_get_products_name((int)$_POST['products_id'])), 'success');
                               }
-                              tep_redirect(OSCOM::link($goto, tep_get_all_get_params($parameters)));
+                              OSCOM::redirect($goto, tep_get_all_get_params($parameters));
                               break;
       // customer removes a product from their shopping cart
       case 'remove_product' : if (isset($_GET['products_id'])) {
                                 $_SESSION['cart']->remove($_GET['products_id']);
                                 $messageStack->add_session('product_action', sprintf(PRODUCT_REMOVED, tep_get_products_name($_GET['products_id'])), 'warning');
                               }
-                              tep_redirect(OSCOM::link($goto, tep_get_all_get_params($parameters)));
+                              OSCOM::redirect($goto, tep_get_all_get_params($parameters));
                               break;
       // performed by the 'buy now' button in product listings and review page
       case 'buy_now' :        if (isset($_GET['products_id'])) {
                                 if (tep_has_product_attributes($_GET['products_id'])) {
-                                  tep_redirect(OSCOM::link('product_info.php', 'products_id=' . $_GET['products_id']));
+                                  OSCOM::redirect('product_info.php', 'products_id=' . $_GET['products_id']);
                                 } else {
                                   $_SESSION['cart']->add_cart($_GET['products_id'], $_SESSION['cart']->get_quantity($_GET['products_id'])+1);
                                   $messageStack->add_session('product_action', sprintf(PRODUCT_ADDED, tep_get_products_name((int)$_GET['products_id'])), 'success');
                                 }
                               }
-                              tep_redirect(OSCOM::link($goto, tep_get_all_get_params($parameters)));
+                              OSCOM::redirect($goto, tep_get_all_get_params($parameters));
                               break;
       case 'notify' :         if ( isset($_SESSION['customer_id']) ) {
                                 if (isset($_GET['products_id'])) {
@@ -321,7 +321,7 @@
                                 } elseif (isset($_POST['notify'])) {
                                   $notify = $_POST['notify'];
                                 } else {
-                                  tep_redirect(OSCOM::link($PHP_SELF, tep_get_all_get_params(array('action', 'notify'))));
+                                  OSCOM::redirect($PHP_SELF, tep_get_all_get_params(array('action', 'notify')));
                                 }
                                 if (!is_array($notify)) $notify = array($notify);
                                 for ($i=0, $n=sizeof($notify); $i<$n; $i++) {
@@ -332,10 +332,10 @@
                                     $messageStack->add_session('product_action', sprintf(PRODUCT_SUBSCRIBED, tep_get_products_name((int)$notify[$i])), 'success');
                                   }
                                 }
-                                tep_redirect(OSCOM::link($PHP_SELF, tep_get_all_get_params(array('action', 'notify'))));
+                                OSCOM::redirect($PHP_SELF, tep_get_all_get_params(array('action', 'notify')));
                               } else {
                                 $_SESSION['navigation']->set_snapshot();
-                                tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+                                OSCOM::redirect('login.php', '', 'SSL');
                               }
                               break;
       case 'notify_remove' :  if ( isset($_SESSION['customer_id']) && isset($_GET['products_id'])) {
@@ -345,20 +345,20 @@
                                   $OSCOM_Db->delete('products_notifications', ['customers_id' => $_SESSION['customer_id'], 'products_id' => $_GET['products_id']]);
                                   $messageStack->add_session('product_action', sprintf(PRODUCT_UNSUBSCRIBED, tep_get_products_name((int)$_GET['products_id'])), 'warning');
                                 }
-                                tep_redirect(OSCOM::link($PHP_SELF, tep_get_all_get_params(array('action'))));
+                                OSCOM::redirect($PHP_SELF, tep_get_all_get_params(array('action')));
                               } else {
                                 $_SESSION['navigation']->set_snapshot();
-                                tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+                                OSCOM::redirect('login.php', '', 'SSL');
                               }
                               break;
       case 'cust_order' :     if ( isset($_SESSION['customer_id']) && isset($_GET['pid']) ) {
                                 if (tep_has_product_attributes($_GET['pid'])) {
-                                  tep_redirect(OSCOM::link('product_info.php', 'products_id=' . $_GET['pid']));
+                                  OSCOM::redirect('product_info.php', 'products_id=' . $_GET['pid']);
                                 } else {
                                   $_SESSION['cart']->add_cart($_GET['pid'], $_SESSION['cart']->get_quantity($_GET['pid'])+1);
                                 }
                               }
-                              tep_redirect(OSCOM::link($goto, tep_get_all_get_params($parameters)));
+                              OSCOM::redirect($goto, tep_get_all_get_params($parameters));
                               break;
     }
   }

--- a/catalog/includes/functions/general.php
+++ b/catalog/includes/functions/general.php
@@ -34,30 +34,6 @@
   }
 
 ////
-// Redirect to another page or site
-  function tep_redirect($url) {
-    global $request_type;
-
-    if ( (strstr($url, "\n") != false) || (strstr($url, "\r") != false) ) {
-      tep_redirect(OSCOM::link('index.php', '', 'NONSSL', false));
-    }
-
-    if ( (ENABLE_SSL == true) && ($request_type == 'SSL') ) { // We are loading an SSL page
-      if (substr($url, 0, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)) == HTTP_SERVER . DIR_WS_HTTP_CATALOG) { // NONSSL url
-        $url = HTTPS_SERVER . DIR_WS_HTTPS_CATALOG . substr($url, strlen(HTTP_SERVER . DIR_WS_HTTP_CATALOG)); // Change it to SSL
-      }
-    }
-
-    if ( strpos($url, '&amp;') !== false ) {
-      $url = str_replace('&amp;', '&', $url);
-    }
-
-    header('Location: ' . $url);
-
-    tep_exit();
-  }
-
-////
 // Parse the data used in the html tags to ensure the tags will not break
     function tep_output_string($string, $translate = false, $protected = false) {
     if ($protected == true) {

--- a/catalog/includes/functions/sessions.php
+++ b/catalog/includes/functions/sessions.php
@@ -100,7 +100,7 @@
     }
 
     if ($sane_session_id == false) {
-      tep_redirect(OSCOM::link('index.php', '', 'NONSSL', false));
+      OSCOM::redirect('index.php', '', 'NONSSL', false);
     }
 
     register_shutdown_function('session_write_close');

--- a/catalog/includes/modules/content/checkout_success/cm_cs_redirect_old_order.php
+++ b/catalog/includes/modules/content/checkout_success/cm_cs_redirect_old_order.php
@@ -46,7 +46,7 @@
         $Qcheck->execute();
 
         if ($Qcheck->fetch() !== false) {
-          tep_redirect(OSCOM::link('account.php', '', 'SSL'));
+          OSCOM::redirect('account.php', '', 'SSL');
         }
       }
     }

--- a/catalog/includes/modules/payment/braintree_cc.php
+++ b/catalog/includes/modules/payment/braintree_cc.php
@@ -260,7 +260,7 @@
               }
 
               if ( !isset($braintree_token_cvv) || empty($braintree_token_cvv) ) {
-                tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardcvv', 'SSL'));
+                OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardcvv', 'SSL');
               }
             }
           }
@@ -291,28 +291,28 @@
         }
 
         if ( !isset($cc_owner) || empty($cc_owner) ) {
-          tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardowner', 'SSL'));
+          OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardowner', 'SSL');
         }
 
         if ( !isset($cc_number) || empty($cc_number) ) {
-          tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardnumber', 'SSL'));
+          OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardnumber', 'SSL');
         }
 
         if ( !isset($cc_expires_month) || !in_array($cc_expires_month, $months_array) ) {
-          tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL'));
+          OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL');
         }
 
         if ( !isset($cc_expires_year) || !in_array($cc_expires_year, $years_array) ) {
-          tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL'));
+          OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL');
         }
 
         if ( ($cc_expires_year == date('Y')) && ($cc_expires_month < date('m')) ) {
-          tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL'));
+          OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL');
         }
 
         if ( MODULE_PAYMENT_BRAINTREE_CC_VERIFY_WITH_CVV == 'True' ) {
           if ( !isset($cc_cvv) || empty($cc_cvv) ) {
-            tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardcvv', 'SSL'));
+            OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardcvv', 'SSL');
           }
         }
       }
@@ -413,7 +413,7 @@
         $_SESSION['braintree_error'] = $braintree_error;
       }
 
-      tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code, 'SSL'));
+      OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code, 'SSL');
     }
 
     function after_process() {

--- a/catalog/includes/modules/payment/sage_pay_direct.php
+++ b/catalog/includes/modules/payment/sage_pay_direct.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
   use OSC\OM\Registry;
 
@@ -280,7 +281,7 @@
 
             $transaction_response = $this->sendTransactionToGateway($gateway_url, $post_string);
           } elseif ( isset($_POST['StatusDetail']) && ($_POST['StatusDetail'] == 'Paypal transaction cancelled by client.') ) {
-            tep_redirect(OSCOM::link('checkout_confirmation.php', '', 'SSL'));
+            OSCOM::redirect('checkout_confirmation.php', '', 'SSL');
           }
         }
       } else {
@@ -305,7 +306,7 @@
           $cc_type = isset($_POST['cc_type']) ? substr($_POST['cc_type'], 0, 15) : null;
 
           if ( !isset($cc_type) || ($this->isCard($cc_type) == false) ) {
-            tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardtype', 'SSL'));
+            OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardtype', 'SSL');
           }
 
           if ( $cc_type != 'PAYPAL' ) {
@@ -334,48 +335,48 @@
             }
 
             if ( !isset($cc_owner) || empty($cc_owner) ) {
-              tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardowner', 'SSL'));
+              OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardowner', 'SSL');
             }
 
             if ( !isset($cc_number) || (is_numeric($cc_number) == false) ) {
-              tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardnumber', 'SSL'));
+              OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardnumber', 'SSL');
             }
 
             if ( (($cc_type == 'MAESTRO') && (MODULE_PAYMENT_SAGE_PAY_DIRECT_ALLOW_MAESTRO == 'True')) || (($cc_type == 'AMEX') && (MODULE_PAYMENT_SAGE_PAY_DIRECT_ALLOW_AMEX == 'True')) ) {
               if ( !isset($_POST['cc_starts_month']) || !in_array($_POST['cc_starts_month'], $months_array) ) {
-                tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardstart', 'SSL'));
+                OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardstart', 'SSL');
               }
 
               if ( !isset($_POST['cc_starts_year']) || !in_array($_POST['cc_starts_year'], $year_valid_from_array) ) {
-                tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardstart', 'SSL'));
+                OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardstart', 'SSL');
               }
 
               $cc_start = substr($_POST['cc_starts_month'] . $_POST['cc_starts_year'], 0, 4);
             }
 
             if ( !isset($_POST['cc_expires_month']) || !in_array($_POST['cc_expires_month'], $months_array) ) {
-              tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL'));
+              OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL');
             }
 
             if ( !isset($_POST['cc_expires_year']) || !in_array($_POST['cc_expires_year'], $year_valid_to_array) ) {
-              tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL'));
+              OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL');
             }
 
             if ( ($_POST['cc_expires_year'] == date('y')) && ($_POST['cc_expires_month'] < date('m')) ) {
-              tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL'));
+              OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardexpires', 'SSL');
             }
 
             $cc_expires = substr($_POST['cc_expires_month'] . $_POST['cc_expires_year'], 0, 4);
 
             if ( (($cc_type == 'MAESTRO') && (MODULE_PAYMENT_SAGE_PAY_DIRECT_ALLOW_MAESTRO == 'True')) ) {
               if ( !isset($cc_issue) || empty($cc_issue) ) {
-                tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardissue', 'SSL'));
+                OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardissue', 'SSL');
               }
             }
 
             if (MODULE_PAYMENT_SAGE_PAY_DIRECT_VERIFY_WITH_CVC == 'True') {
               if ( !isset($cc_cvc) || empty($cc_cvc) ) {
-                tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardcvc', 'SSL'));
+                OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . '&error=cardcvc', 'SSL');
               }
             }
           }
@@ -516,11 +517,11 @@
         $_SESSION['sage_pay_direct_pareq'] = $sage_pay_response['PAReq'];
         $_SESSION['sage_pay_direct_md'] = $sage_pay_response['MD'];
 
-        tep_redirect(OSCOM::link('ext/modules/payment/sage_pay/checkout.php', '', 'SSL'));
+        OSCOM::redirect('ext/modules/payment/sage_pay/checkout.php', '', 'SSL');
       }
 
       if ($sage_pay_response['Status'] == 'PPREDIRECT') {
-        tep_redirect($sage_pay_response['PayPalRedirectURL']);
+        HTTP::redirect($sage_pay_response['PayPalRedirectURL']);
       }
 
       if ( ($sage_pay_response['Status'] != 'OK') && ($sage_pay_response['Status'] != 'AUTHENTICATED') && ($sage_pay_response['Status'] != 'REGISTERED') ) {
@@ -528,7 +529,7 @@
 
         $error = $this->getErrorMessageNumber($sage_pay_response['StatusDetail']);
 
-        tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . (tep_not_null($error) ? '&error=' . $error : ''), 'SSL'));
+        OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . (tep_not_null($error) ? '&error=' . $error : ''), 'SSL');
       }
     }
 

--- a/catalog/includes/modules/payment/sage_pay_form.php
+++ b/catalog/includes/modules/payment/sage_pay_form.php
@@ -235,10 +235,10 @@
 
           $error = $this->getErrorMessageNumber($sage_pay_response['StatusDetail']);
 
-          tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . (tep_not_null($error) ? '&error=' . $error : ''), 'SSL'));
+          OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . (tep_not_null($error) ? '&error=' . $error : ''), 'SSL');
         }
       } else {
-        tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code, 'SSL'));
+        OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code, 'SSL');
       }
     }
 

--- a/catalog/includes/modules/payment/sage_pay_server.php
+++ b/catalog/includes/modules/payment/sage_pay_server.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
   use OSC\OM\Registry;
 
@@ -254,11 +255,11 @@
           }
 
           if ( MODULE_PAYMENT_SAGE_PAY_SERVER_PROFILE_PAGE == 'Normal' ) {
-            tep_redirect($return['NextURL']);
+            HTTP::redirect($return['NextURL']);
           } else {
             $_SESSION['sage_pay_server_nexturl'] = $return['NextURL'];
 
-            tep_redirect(OSCOM::link('ext/modules/payment/sage_pay/checkout.php', '', 'SSL'));
+            OSCOM::redirect('ext/modules/payment/sage_pay/checkout.php', '', 'SSL');
           }
         } else {
           $error = $this->getErrorMessageNumber($return['StatusDetail']);
@@ -267,7 +268,7 @@
         }
       }
 
-      tep_redirect(OSCOM::link('checkout_payment.php', 'payment_error=' . $this->code . (tep_not_null($error) ? '&error=' . $error : ''), 'SSL'));
+      OSCOM::redirect('checkout_payment.php', 'payment_error=' . $this->code . (tep_not_null($error) ? '&error=' . $error : ''), 'SSL');
     }
 
     function after_process() {
@@ -295,7 +296,7 @@
 
         unset($_SESSION['sage_pay_server_nexturl']);
 
-        tep_redirect(OSCOM::link('ext/modules/payment/sage_pay/redirect.php', '', 'SSL'));
+        OSCOM::redirect('ext/modules/payment/sage_pay/redirect.php', '', 'SSL');
       }
     }
 

--- a/catalog/login.php
+++ b/catalog/login.php
@@ -10,6 +10,7 @@
   Released under the GNU General Public License
 */
 
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -19,10 +20,10 @@
     if ( !isset($_GET['cookie_test']) ) {
       $all_get = tep_get_all_get_params();
 
-      tep_redirect(OSCOM::link('login.php', $all_get . (empty($all_get) ? '' : '&') . 'cookie_test=1', 'SSL'));
+      HTTP::redirect(OSCOM::link('login.php', $all_get . (empty($all_get) ? '' : '&') . 'cookie_test=1', 'SSL'));
     }
 
-    tep_redirect(OSCOM::link('cookie_usage.php'));
+    HTTP::redirect(OSCOM::link('cookie_usage.php'));
   }
 
 // login content module must return $login_customer_id as an integer after successful customer authentication
@@ -58,10 +59,10 @@
     if (sizeof($_SESSION['navigation']->snapshot) > 0) {
       $origin_href = OSCOM::link($_SESSION['navigation']->snapshot['page'], tep_array_to_string($_SESSION['navigation']->snapshot['get'], array(session_name())), $_SESSION['navigation']->snapshot['mode']);
       $_SESSION['navigation']->clear_snapshot();
-      tep_redirect($origin_href);
+      HTTP::redirect($origin_href);
     }
 
-    tep_redirect(OSCOM::link('index.php'));
+    HTTP::redirect(OSCOM::link('index.php'));
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/login.php');

--- a/catalog/login.php
+++ b/catalog/login.php
@@ -20,10 +20,10 @@
     if ( !isset($_GET['cookie_test']) ) {
       $all_get = tep_get_all_get_params();
 
-      HTTP::redirect(OSCOM::link('login.php', $all_get . (empty($all_get) ? '' : '&') . 'cookie_test=1', 'SSL'));
+      OSCOM::redirect('login.php', $all_get . (empty($all_get) ? '' : '&') . 'cookie_test=1', 'SSL');
     }
 
-    HTTP::redirect(OSCOM::link('cookie_usage.php'));
+    OSCOM::redirect('cookie_usage.php');
   }
 
 // login content module must return $login_customer_id as an integer after successful customer authentication
@@ -62,7 +62,7 @@
       HTTP::redirect($origin_href);
     }
 
-    HTTP::redirect(OSCOM::link('index.php'));
+    OSCOM::redirect('index.php');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/login.php');

--- a/catalog/password_reset.php
+++ b/catalog/password_reset.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -57,7 +58,7 @@
   }
 
   if ($error == true) {
-    tep_redirect(OSCOM::link('password_forgotten.php'));
+    HTTP::redirect(OSCOM::link('password_forgotten.php'));
   }
 
   if (isset($_GET['action']) && ($_GET['action'] == 'process') && isset($_POST['formid']) && ($_POST['formid'] == $_SESSION['sessiontoken'])) {
@@ -81,7 +82,7 @@
 
       $messageStack->add_session('login', SUCCESS_PASSWORD_RESET, 'success');
 
-      tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+      HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
     }
   }
 

--- a/catalog/password_reset.php
+++ b/catalog/password_reset.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -58,7 +57,7 @@
   }
 
   if ($error == true) {
-    HTTP::redirect(OSCOM::link('password_forgotten.php'));
+    OSCOM::redirect('password_forgotten.php');
   }
 
   if (isset($_GET['action']) && ($_GET['action'] == 'process') && isset($_POST['formid']) && ($_POST['formid'] == $_SESSION['sessiontoken'])) {
@@ -82,7 +81,7 @@
 
       $messageStack->add_session('login', SUCCESS_PASSWORD_RESET, 'success');
 
-      HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+      OSCOM::redirect('login.php', '', 'SSL');
     }
   }
 

--- a/catalog/product_info.php
+++ b/catalog/product_info.php
@@ -11,13 +11,12 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_GET['products_id'])) {
-    HTTP::redirect(OSCOM::link('index.php'));
+    OSCOM::redirect('index.php');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/product_info.php');

--- a/catalog/product_info.php
+++ b/catalog/product_info.php
@@ -11,12 +11,13 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_GET['products_id'])) {
-    tep_redirect(OSCOM::link('index.php'));
+    HTTP::redirect(OSCOM::link('index.php'));
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/product_info.php');

--- a/catalog/product_reviews.php
+++ b/catalog/product_reviews.php
@@ -11,13 +11,12 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_GET['products_id'])) {
-    HTTP::redirect(OSCOM::link('reviews.php'));
+    OSCOM::redirect('reviews.php');
   }
 
   $Qcheck = $OSCOM_Db->prepare('select p.products_id, p.products_model, p.products_image, p.products_price, p.products_tax_class_id, pd.products_name from :table_products p, :table_products_description pd where p.products_id = :products_id and p.products_status = 1 and p.products_id = pd.products_id and pd.language_id = :language_id');
@@ -26,7 +25,7 @@
   $Qcheck->execute();
 
   if ( $Qcheck->fetch() === false ) {
-    HTTP::redirect(OSCOM::link('reviews.php'));
+    OSCOM::redirect('reviews.php');
   }
 
   if ( $new_price = tep_get_products_special_price($Qcheck->valueInt('products_id')) ) {

--- a/catalog/product_reviews.php
+++ b/catalog/product_reviews.php
@@ -11,12 +11,13 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_GET['products_id'])) {
-    tep_redirect(OSCOM::link('reviews.php'));
+    HTTP::redirect(OSCOM::link('reviews.php'));
   }
 
   $Qcheck = $OSCOM_Db->prepare('select p.products_id, p.products_model, p.products_image, p.products_price, p.products_tax_class_id, pd.products_name from :table_products p, :table_products_description pd where p.products_id = :products_id and p.products_status = 1 and p.products_id = pd.products_id and pd.language_id = :language_id');
@@ -25,7 +26,7 @@
   $Qcheck->execute();
 
   if ( $Qcheck->fetch() === false ) {
-    tep_redirect(OSCOM::link('reviews.php'));
+    HTTP::redirect(OSCOM::link('reviews.php'));
   }
 
   if ( $new_price = tep_get_products_special_price($Qcheck->valueInt('products_id')) ) {

--- a/catalog/product_reviews_write.php
+++ b/catalog/product_reviews_write.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -19,11 +20,11 @@
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
   if (!isset($_GET['products_id'])) {
-    tep_redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
+    HTTP::redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
   }
 
   $Qcheck = $OSCOM_Db->prepare('select p.products_id, p.products_model, p.products_image, p.products_price, p.products_tax_class_id, pd.products_name from :table_products p, :table_products_description pd where p.products_id = :products_id and p.products_status = 1 and p.products_id = pd.products_id and pd.language_id = :language_id');
@@ -32,7 +33,7 @@
   $Qcheck->execute();
 
   if ( $Qcheck->fetch() === false ) {
-    tep_redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
+    HTTP::redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
   }
 
   $Qcustomer = $OSCOM_Db->get('customers', ['customers_firstname', 'customers_lastname'], ['customers_id' => $_SESSION['customer_id']]);
@@ -61,7 +62,7 @@
       $OSCOM_Db->save('reviews_description', ['reviews_id' => $insert_id, 'languages_id' => $_SESSION['languages_id'], 'reviews_text' => $review]);
 
       $messageStack->add_session('product_reviews', TEXT_REVIEW_RECEIVED, 'success');
-      tep_redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
+      HTTP::redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
     }
   }
 

--- a/catalog/product_reviews_write.php
+++ b/catalog/product_reviews_write.php
@@ -11,7 +11,6 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -20,11 +19,11 @@
 
   if (!isset($_SESSION['customer_id'])) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   if (!isset($_GET['products_id'])) {
-    HTTP::redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
+    OSCOM::redirect('product_reviews.php', tep_get_all_get_params(array('action')));
   }
 
   $Qcheck = $OSCOM_Db->prepare('select p.products_id, p.products_model, p.products_image, p.products_price, p.products_tax_class_id, pd.products_name from :table_products p, :table_products_description pd where p.products_id = :products_id and p.products_status = 1 and p.products_id = pd.products_id and pd.language_id = :language_id');
@@ -33,7 +32,7 @@
   $Qcheck->execute();
 
   if ( $Qcheck->fetch() === false ) {
-    HTTP::redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
+    OSCOM::redirect('product_reviews.php', tep_get_all_get_params(array('action')));
   }
 
   $Qcustomer = $OSCOM_Db->get('customers', ['customers_firstname', 'customers_lastname'], ['customers_id' => $_SESSION['customer_id']]);
@@ -62,7 +61,7 @@
       $OSCOM_Db->save('reviews_description', ['reviews_id' => $insert_id, 'languages_id' => $_SESSION['languages_id'], 'reviews_text' => $review]);
 
       $messageStack->add_session('product_reviews', TEXT_REVIEW_RECEIVED, 'success');
-      HTTP::redirect(OSCOM::link('product_reviews.php', tep_get_all_get_params(array('action'))));
+      OSCOM::redirect('product_reviews.php', tep_get_all_get_params(array('action')));
     }
   }
 

--- a/catalog/redirect.php
+++ b/catalog/redirect.php
@@ -11,6 +11,7 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
@@ -21,7 +22,7 @@
       if ($Qbanner->fetch() !== false) {
         tep_update_banner_click_count($_GET['goto']);
 
-        tep_redirect($Qbanner->value('banners_url'));
+        HTTP::redirect($Qbanner->value('banners_url'));
       }
       break;
 
@@ -29,7 +30,7 @@
       if (isset($_GET['goto']) && tep_not_null($_GET['goto'])) {
         $Qcheck = $OSCOM_Db->get('products_description', 'products_url', ['products_url' => HTML::sanitize($_GET['goto'])], null, 1);
         if ($Qcheck->fetch() !== false) {
-          tep_redirect('http://' . $Qcheck->value('products_url'));
+          HTTP::redirect('http://' . $Qcheck->value('products_url'));
         }
       }
       break;
@@ -46,7 +47,7 @@
             $Qupdate->bindInt(':languages_id', $_SESSION['languages_id']);
             $Qupdate->execute();
 
-            tep_redirect($Qmanufacturer->value('manufacturers_url'));
+            HTTP::redirect($Qmanufacturer->value('manufacturers_url'));
           }
         } else {
 // no url exists for the selected language, lets use the default language then
@@ -62,7 +63,7 @@
               $Qupdate->bindInt(':languages_id', $Qmanufacturer->valueInt('languages_id'));
               $Qupdate->execute();
 
-              tep_redirect($Qmanufacturer->value('manufacturers_url'));
+              HTTP::redirect($Qmanufacturer->value('manufacturers_url'));
             }
           }
         }
@@ -70,5 +71,5 @@
       break;
   }
 
-  tep_redirect(OSCOM::link('index.php'));
+  HTTP::redirect(OSCOM::link('index.php'));
 ?>

--- a/catalog/redirect.php
+++ b/catalog/redirect.php
@@ -71,5 +71,5 @@
       break;
   }
 
-  HTTP::redirect(OSCOM::link('index.php'));
+  OSCOM::redirect('index.php');
 ?>

--- a/catalog/tell_a_friend.php
+++ b/catalog/tell_a_friend.php
@@ -11,13 +11,14 @@
 */
 
   use OSC\OM\HTML;
+  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id']) && (ALLOW_GUEST_TO_TELL_A_FRIEND == 'false')) {
     $_SESSION['navigation']->set_snapshot();
-    tep_redirect(OSCOM::link('login.php', '', 'SSL'));
+    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
   }
 
   $valid_product = false;
@@ -33,7 +34,7 @@
   }
 
   if ($valid_product == false) {
-    tep_redirect(OSCOM::link('index.php'));
+    HTTP::redirect(OSCOM::link('index.php'));
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/tell_a_friend.php');
@@ -100,7 +101,7 @@
 
       $messageStack->add_session('header', sprintf(TEXT_EMAIL_SUCCESSFUL_SENT, $Qproduct->value('products_name'), tep_output_string_protected($to_name)), 'success');
 
-      tep_redirect(OSCOM::link('product_info.php', 'products_id=' . $Qproduct->valueInt('products_id')));
+      HTTP::redirect(OSCOM::link('product_info.php', 'products_id=' . $Qproduct->valueInt('products_id')));
     }
   } elseif (isset($_SESSION['customer_id'])) {
     $Qcustomer = $OSCOM_Db->get('customers', ['customers_firstname', 'customers_lastname', 'customers_email_address'], ['customers_id' => $_SESSION['customer_id']]);

--- a/catalog/tell_a_friend.php
+++ b/catalog/tell_a_friend.php
@@ -11,14 +11,13 @@
 */
 
   use OSC\OM\HTML;
-  use OSC\OM\HTTP;
   use OSC\OM\OSCOM;
 
   require('includes/application_top.php');
 
   if (!isset($_SESSION['customer_id']) && (ALLOW_GUEST_TO_TELL_A_FRIEND == 'false')) {
     $_SESSION['navigation']->set_snapshot();
-    HTTP::redirect(OSCOM::link('login.php', '', 'SSL'));
+    OSCOM::redirect('login.php', '', 'SSL');
   }
 
   $valid_product = false;
@@ -34,7 +33,7 @@
   }
 
   if ($valid_product == false) {
-    HTTP::redirect(OSCOM::link('index.php'));
+    OSCOM::redirect('index.php');
   }
 
   require(DIR_WS_LANGUAGES . $_SESSION['language'] . '/tell_a_friend.php');
@@ -101,7 +100,7 @@
 
       $messageStack->add_session('header', sprintf(TEXT_EMAIL_SUCCESSFUL_SENT, $Qproduct->value('products_name'), tep_output_string_protected($to_name)), 'success');
 
-      HTTP::redirect(OSCOM::link('product_info.php', 'products_id=' . $Qproduct->valueInt('products_id')));
+      OSCOM::redirect('product_info.php', 'products_id=' . $Qproduct->valueInt('products_id'));
     }
   } elseif (isset($_SESSION['customer_id'])) {
     $Qcustomer = $OSCOM_Db->get('customers', ['customers_firstname', 'customers_lastname', 'customers_email_address'], ['customers_id' => $_SESSION['customer_id']]);


### PR DESCRIPTION
OSCOM::redirect() magically passes its parameters to OSCOM::link() to generate an internal url, then uses HTTP::redirect() where the actual redirect code exists.