### PR TITLE
Database tables edits - errors in paypal_standard module

### DIFF
--- a/catalog/includes/modules/payment/paypal_standard.php
+++ b/catalog/includes/modules/payment/paypal_standard.php
@@ -285,7 +285,7 @@
                                         'options_values_price' => $attributes_values['options_values_price'],
                                         'price_prefix' => $attributes_values['price_prefix']);
 
-                tep_db_perform(orders_products_attributes, $sql_data_array);
+                tep_db_perform('orders_products_attributes', $sql_data_array);
 
                 if ((DOWNLOAD_ENABLED == 'true') && isset($attributes_values['products_attributes_filename']) && tep_not_null($attributes_values['products_attributes_filename'])) {
                   $sql_data_array = array('orders_id' => $insert_id,

--- a/catalog/includes/modules/payment/paypal_standard.php
+++ b/catalog/includes/modules/payment/paypal_standard.php
@@ -105,7 +105,7 @@
           tep_db_query('delete from orders where orders_id = "' . (int)$order_id . '"');
           tep_db_query('delete from orders_total where orders_id = "' . (int)$order_id . '"');
           tep_db_query('delete from orders_status_history where orders_id = "' . (int)$order_id . '"');
-          tep_db_query('delete from orders_productswhere orders_id = "' . (int)$order_id . '"');
+          tep_db_query('delete from orders_products where orders_id = "' . (int)$order_id . '"');
           tep_db_query('delete from orders_products_attributes where orders_id = "' . (int)$order_id . '"');
           tep_db_query('delete from orders_products_download where orders_id = "' . (int)$order_id . '"');
 
@@ -151,7 +151,7 @@
               tep_db_query('delete from orders where orders_id = "' . (int)$order_id . '"');
               tep_db_query('delete from orders_total where orders_id = "' . (int)$order_id . '"');
               tep_db_query('delete from orders_status_history where orders_id = "' . (int)$order_id . '"');
-              tep_db_query('delete from orders_productswhere orders_id = "' . (int)$order_id . '"');
+              tep_db_query('delete from orders_products where orders_id = "' . (int)$order_id . '"');
               tep_db_query('delete from orders_products_attributes where orders_id = "' . (int)$order_id . '"');
               tep_db_query('delete from orders_products_download where orders_id = "' . (int)$order_id . '"');
             }


### PR DESCRIPTION
A couple of edit errors in paypal_standard.php when deprecating includes/database_tables.php