### PR TITLE
Apache 2.4 support without mod_access_compat

### DIFF
--- a/catalog/admin/backups/.htaccess
+++ b/catalog/admin/backups/.htaccess
@@ -19,6 +19,11 @@
 Options -Indexes
 
 <Files *>
-Order Deny,Allow
-Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </Files>

--- a/catalog/admin/images/.htaccess
+++ b/catalog/admin/images/.htaccess
@@ -5,6 +5,11 @@
 
 # Prevents any script files from being accessed from the images folder
 <FilesMatch "\.(php([0-9]|s)?|s?p?html|cgi|pl|exe)$">
-   Order Deny,Allow
-   Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </FilesMatch>

--- a/catalog/admin/includes/.htaccess
+++ b/catalog/admin/includes/.htaccess
@@ -17,6 +17,11 @@
 # Example: http://server/catalog/admin/includes/application_top.php will not work
 
 <Files *.php>
-Order Deny,Allow
-Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </Files>

--- a/catalog/images/.htaccess
+++ b/catalog/images/.htaccess
@@ -5,8 +5,13 @@
 
 # Prevents any script files from being accessed from the images folder
 <FilesMatch "\.(php([0-9]|s)?|s?p?html|cgi|pl|exe)$">
-   Order Deny,Allow
-   Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </FilesMatch>
 
 Options -Indexes

--- a/catalog/includes/.htaccess
+++ b/catalog/includes/.htaccess
@@ -17,6 +17,11 @@
 # Example: http://server/catalog/includes/application_top.php will not work
 
 <Files *.php>
-Order Deny,Allow
-Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </Files>

--- a/catalog/includes/work/.htaccess
+++ b/catalog/includes/work/.htaccess
@@ -1,4 +1,9 @@
 <Files *>
-  Order Deny,Allow
-  Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </Files>


### PR DESCRIPTION
"The directives provided by mod_access_compat have been deprecated"