### PR TITLE
Fixed arbitrary upload vulnerability

### DIFF
--- a/catalog/admin/newsletters.php
+++ b/catalog/admin/newsletters.php
@@ -29,6 +29,11 @@
       case 'update':
         if (isset($_POST['newsletter_id'])) $newsletter_id = tep_db_prepare_input($_POST['newsletter_id']);
         $newsletter_module = tep_db_prepare_input($_POST['module']);
+        
+        // Check if the user has inputted something malicious ( Everything else other than the 2 allowed modules )
++        if($newsletter_module != "newsletter" and $newsletter != "product_notification")
++                tep_redirect(tep_href_link('newsletters.php')); // Redirect and exit execution
+
         $title = tep_db_prepare_input($_POST['title']);
         $content = tep_db_prepare_input($_POST['content']);
 


### PR DESCRIPTION
Hey.

I looked trough the code of the newsletters.php file and found a vulnerability, which allowed a privilege escalation.
The vuln allows attackers that gained an Admin Account to the store to upload arbitary files.

A writeup on the problem can be found here:
http://blog.scannells.tech/uploading-arbitary-files-from-the-oscommerce-admin-panel-via-object-injections/

Password to the blog entry: ?)(4pAd#!dw2

I modified the newsletters.php and added a quick solution for the vuln.
