### PR TITLE
Payment modules count fix

### DIFF
--- a/catalog/includes/functions/general.php
+++ b/catalog/includes/functions/general.php
@@ -1036,7 +1036,7 @@
       } else {
         $module = substr($m, 0, strrpos($m, '.'));
 
-        if (is_object($GLOBALS[$module])) {
+        if (isset($GLOBALS[$module]) && is_object($GLOBALS[$module])) {
           $OSCOM_PM = $GLOBALS[$module];
         }
       }


### PR DESCRIPTION
Standard oscommerce payment modules are no objects on checkout_confirmation  page.